### PR TITLE
HPCC Cirrus makefile: make MKL link options consistent with modules

### DIFF
--- a/synth/HPCC/Make_arch/Cirrus/Make.cirrus_gcc
+++ b/synth/HPCC/Make_arch/Cirrus/Make.cirrus_gcc
@@ -94,7 +94,7 @@ MPlib        =
 #
 LAdir        =
 LAinc        = 
-LAlib        = -L/lustre/sw/intel/compilers_and_libraries_2017.2.174/linux/mkl/lib/intel64 -lmkl_gf_lp64 -lmkl_core -lmkl_sequential -lmkl_scalapack_lp64 -lmkl_blacs_sgimpt_lp64
+LAlib        = -L/lustre/sw/intel/compilers_and_libraries_2017.2.174/linux/mkl/lib/intel64 -lmkl_gf_lp64 -lmkl_core -lmkl_sequential -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64
 #
 # ----------------------------------------------------------------------
 # - F77 / C interface --------------------------------------------------


### PR DESCRIPTION
The Cirrus Makefile had the wrong MKL options to match with the loaded modules detailed in the README.md

This commit corrects that (bless the MKL link advisor...)