### PR TITLE
Fix Wilkes2 specs

### DIFF
--- a/reports/single_node/index.md
+++ b/reports/single_node/index.md
@@ -96,7 +96,7 @@ The tables below provide further technical details on the systems. [Table 1](#ta
 
 | System        | Accelerator Model | Accelerator Memory |
 |---------------|-------------------|-------------------:|
-| Wilkes2-GPU   | P100-SXM2-16GB    | 16 GB              |
+| Wilkes2-GPU   | P100-PCIE-16GB    | 16 GB              |
 | JADE          | P100-SXM2-16GB    | 16 GB              |
 
 <a id="raw"></a>


### PR DESCRIPTION
Cambridge Wilkes2 GPUs are PCI Gen3 form factor, Oxford JAVE GPUs are SXM2 form factor. The GPU micro architecture is the same (Pascal, compute capability 6.0) but SXM2 can sustain higher TDP and so higher clock frequency (which translated in higher FLOPS). SXM2 also has NVLink 1.0 which should provide improved GPU-to-GPU intra-node transfer throughput via IPC GPU Direct.