### PR TITLE
Sulis CASTEP al3x3 benchmarks

### DIFF
--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_16nodes_2048ranks_1threads_8smp_202109031337_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_16nodes_2048ranks_1threads_8smp_202109031337_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:35:20 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 2048 processes.
+ Data is distributed by G-vector(1024-way) and k-point(2-way)
+ G-vector communication optimised for up to 8-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          8
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      501.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               33.1 MB         0.0 MB |
+| Electronic energy minimisation requirements          14.0 MB         0.0 MB |
+| Force calculation requirements                        0.2 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          548.1 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93938735E+004  0.00000000E+000                        14.85  <-- SCF
+      1  -7.23915703E+004  4.08965266E+000   4.81396176E+001      28.34  <-- SCF
+      2  -7.78238485E+004  1.98693143E+000   2.01195490E+001      37.67  <-- SCF
+      3  -7.79864605E+004  1.80530894E+000   6.02266737E-001      47.38  <-- SCF
+      4  -7.78412536E+004  1.95933925E+000  -5.37803624E-001      58.59  <-- SCF
+      5  -7.77211176E+004  1.34897620E+000  -4.44948129E-001      69.05  <-- SCF
+      6  -7.77152215E+004  1.12214673E+000  -2.18372861E-002      80.71  <-- SCF
+      7  -7.77129492E+004  1.05288719E+000  -8.41589137E-003      90.98  <-- SCF
+      8  -7.77104523E+004  1.02762745E+000  -9.24783422E-003     101.67  <-- SCF
+      9  -7.77084312E+004  9.96492776E-001  -7.48547764E-003     112.06  <-- SCF
+     10  -7.77059792E+004  1.11125042E+000  -9.08165403E-003     122.56  <-- SCF
+     11  -7.77052112E+004  1.16239873E+000  -2.84445792E-003     132.53  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21115320     eV
+Final free energy (E-TS)    =  -77705.21115320     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21115320     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.17130      0.02364      0.83722 *
+ * O               2     -0.10402      0.12364      0.83920 *
+ * O               3     -0.05996     -0.15056      0.83965 *
+ * O               4     -0.10701      0.02284      0.38137 *
+ * O               5      0.02294     -0.09798      0.38367 *
+ * O               6      0.07919      0.07530      0.38785 *
+ * O               7     -1.66559      1.77399     -1.01340 *
+ * O               8     -0.67758     -2.28244     -1.01603 *
+ * O               9      2.32624      0.54659     -1.02322 *
+ * O              10      0.08956     -0.01489     -0.38759 *
+ * O              11     -0.02593      0.08081     -0.39317 *
+ * O              12     -0.06520     -0.06290     -0.38992 *
+ * O              13      1.67030     -1.79103      0.94872 *
+ * O              14      0.70377      2.30877      0.96049 *
+ * O              15     -2.39337     -0.54209      0.95464 *
+ * O              16     -0.17651     -0.00923     -0.78370 *
+ * O              17      0.09706     -0.13714     -0.78740 *
+ * O              18      0.07817      0.15164     -0.78775 *
+ * O              19      0.16244      0.02154      0.83840 *
+ * O              20     -0.10159      0.12628      0.83997 *
+ * O              21     -0.06404     -0.14946      0.83605 *
+ * O              22     -0.10108      0.02479      0.38423 *
+ * O              23      0.01971     -0.10150      0.38979 *
+ * O              24      0.07771      0.07754      0.38484 *
+ * O              25     -1.66292      1.75839     -1.02626 *
+ * O              26     -0.68637     -2.30043     -1.02783 *
+ * O              27      2.36688      0.55548     -1.03150 *
+ * O              28      0.07998     -0.01469     -0.39387 *
+ * O              29     -0.02181      0.08484     -0.39038 *
+ * O              30     -0.05464     -0.06608     -0.39252 *
+ * O              31      1.64122     -1.75754      0.95599 *
+ * O              32      0.71336      2.31504      0.96658 *
+ * O              33     -2.38329     -0.54844      0.95970 *
+ * O              34     -0.17537     -0.00701     -0.78568 *
+ * O              35      0.09002     -0.13739     -0.77888 *
+ * O              36      0.07726      0.14874     -0.78759 *
+ * O              37      0.17202      0.02581      0.83816 *
+ * O              38     -0.10009      0.12788      0.83511 *
+ * O              39     -0.05975     -0.14571      0.83322 *
+ * O              40     -0.09788      0.03148      0.38127 *
+ * O              41      0.02564     -0.10058      0.38422 *
+ * O              42      0.07727      0.07346      0.38648 *
+ * O              43     -1.64124      1.73193     -1.02047 *
+ * O              44     -0.68989     -2.29424     -1.02068 *
+ * O              45      2.35403      0.55700     -1.02470 *
+ * O              46      0.08909     -0.01341     -0.38680 *
+ * O              47     -0.02620      0.08169     -0.39353 *
+ * O              48     -0.05611     -0.06101     -0.39119 *
+ * O              49      1.66125     -1.79342      0.95551 *
+ * O              50      0.68510      2.27782      0.96327 *
+ * O              51     -2.36706     -0.54087      0.97186 *
+ * O              52     -0.17303     -0.01672     -0.78720 *
+ * O              53      0.10279     -0.13984     -0.77611 *
+ * O              54      0.07253      0.15436     -0.78617 *
+ * O              55      0.16471      0.02724      0.83931 *
+ * O              56     -0.10050      0.13358      0.83037 *
+ * O              57     -0.06101     -0.15459      0.84290 *
+ * O              58     -0.09955      0.02632      0.38949 *
+ * O              59      0.02137     -0.09763      0.38663 *
+ * O              60      0.07318      0.07463      0.38495 *
+ * O              61     -1.66716      1.76037     -1.02616 *
+ * O              62     -0.70553     -2.32539     -1.02630 *
+ * O              63      2.36292      0.55632     -1.03150 *
+ * O              64      0.08394     -0.01443     -0.38953 *
+ * O              65     -0.02067      0.07997     -0.39181 *
+ * O              66     -0.05973     -0.06438     -0.38901 *
+ * O              67      1.67637     -1.81094      0.95136 *
+ * O              68      0.70094      2.30610      0.97515 *
+ * O              69     -2.34625     -0.55057      0.96088 *
+ * O              70     -0.17259     -0.00782     -0.77922 *
+ * O              71      0.09648     -0.14029     -0.77821 *
+ * O              72      0.07161      0.14983     -0.77862 *
+ * O              73      0.16489      0.01902      0.83634 *
+ * O              74     -0.10517      0.12910      0.83938 *
+ * O              75     -0.06388     -0.14580      0.84220 *
+ * O              76     -0.09795      0.02668      0.38555 *
+ * O              77      0.01948     -0.09916      0.38689 *
+ * O              78      0.07880      0.07857      0.38526 *
+ * O              79     -1.67007      1.77293     -1.01843 *
+ * O              80     -0.69488     -2.31001     -1.02165 *
+ * O              81      2.35759      0.55702     -1.03539 *
+ * O              82      0.08182     -0.01923     -0.38972 *
+ * O              83     -0.02430      0.08154     -0.39571 *
+ * O              84     -0.05882     -0.05691     -0.38854 *
+ * O              85      1.66459     -1.79232      0.95804 *
+ * O              86      0.71069      2.32723      0.96143 *
+ * O              87     -2.36008     -0.54607      0.96512 *
+ * O              88     -0.17532     -0.00521     -0.79424 *
+ * O              89      0.09445     -0.14516     -0.78260 *
+ * O              90      0.07447      0.15403     -0.78705 *
+ * O              91      0.16048      0.02338      0.83527 *
+ * O              92     -0.09705      0.12503      0.83481 *
+ * O              93     -0.05890     -0.15143      0.83040 *
+ * O              94     -0.10446      0.02532      0.38298 *
+ * O              95      0.02566     -0.10409      0.38184 *
+ * O              96      0.07987      0.07221      0.38449 *
+ * O              97     -1.64881      1.75316     -1.02420 *
+ * O              98     -0.68894     -2.29393     -1.02599 *
+ * O              99      2.32462      0.55053     -1.02790 *
+ * O             100      0.08375     -0.00970     -0.38888 *
+ * O             101     -0.02310      0.08288     -0.38988 *
+ * O             102     -0.05711     -0.05935     -0.38948 *
+ * O             103      1.65112     -1.76147      0.95908 *
+ * O             104      0.69263      2.28622      0.96611 *
+ * O             105     -2.36392     -0.54214      0.96651 *
+ * O             106     -0.16839     -0.00797     -0.79053 *
+ * O             107      0.09977     -0.14325     -0.78142 *
+ * O             108      0.07645      0.15427     -0.78465 *
+ * O             109      0.16682      0.02437      0.83708 *
+ * O             110     -0.09871      0.12558      0.83821 *
+ * O             111     -0.06030     -0.14833      0.83937 *
+ * O             112     -0.10577      0.02427      0.38366 *
+ * O             113      0.02173     -0.09909      0.38394 *
+ * O             114      0.07954      0.07678      0.38339 *
+ * O             115     -1.64147      1.75210     -1.02718 *
+ * O             116     -0.68788     -2.30053     -1.01931 *
+ * O             117      2.33412      0.55624     -1.02660 *
+ * O             118      0.08362     -0.01691     -0.39185 *
+ * O             119     -0.02344      0.07796     -0.39265 *
+ * O             120     -0.05654     -0.06251     -0.38922 *
+ * O             121      1.64438     -1.76089      0.95762 *
+ * O             122      0.69714      2.28356      0.96692 *
+ * O             123     -2.35976     -0.54248      0.96403 *
+ * O             124     -0.17454     -0.00318     -0.79020 *
+ * O             125      0.09786     -0.13712     -0.78228 *
+ * O             126      0.06923      0.15133     -0.78870 *
+ * O             127      0.16308      0.03194      0.83728 *
+ * O             128     -0.10006      0.12599      0.83881 *
+ * O             129     -0.06192     -0.15073      0.83615 *
+ * O             130     -0.10488      0.02418      0.38214 *
+ * O             131      0.02482     -0.09339      0.38230 *
+ * O             132      0.07960      0.07049      0.38676 *
+ * O             133     -1.64464      1.74704     -1.02029 *
+ * O             134     -0.69492     -2.31327     -1.02731 *
+ * O             135      2.35209      0.55958     -1.02593 *
+ * O             136      0.08423     -0.01683     -0.38988 *
+ * O             137     -0.02453      0.08205     -0.39279 *
+ * O             138     -0.05587     -0.06329     -0.38950 *
+ * O             139      1.64781     -1.76987      0.95494 *
+ * O             140      0.70762      2.30702      0.96915 *
+ * O             141     -2.35541     -0.54436      0.96913 *
+ * O             142     -0.17760     -0.01021     -0.78799 *
+ * O             143      0.09673     -0.14161     -0.78080 *
+ * O             144      0.07026      0.14768     -0.77962 *
+ * O             145      0.16469      0.02177      0.84123 *
+ * O             146     -0.10163      0.12986      0.83311 *
+ * O             147     -0.06066     -0.15050      0.84349 *
+ * O             148     -0.10241      0.02840      0.38217 *
+ * O             149      0.01969     -0.09868      0.39327 *
+ * O             150      0.07273      0.07586      0.38230 *
+ * O             151     -1.66484      1.76269     -1.01662 *
+ * O             152     -0.69847     -2.31187     -1.02226 *
+ * O             153      2.37107      0.55916     -1.01937 *
+ * O             154      0.08174     -0.01645     -0.38634 *
+ * O             155     -0.02113      0.08007     -0.39096 *
+ * O             156     -0.06103     -0.06424     -0.39019 *
+ * O             157      1.66481     -1.79272      0.95822 *
+ * O             158      0.69771      2.30004      0.96573 *
+ * O             159     -2.33352     -0.53870      0.96578 *
+ * O             160     -0.16967     -0.01154     -0.78364 *
+ * O             161      0.09368     -0.14314     -0.77210 *
+ * O             162      0.07388      0.15442     -0.77993 *
+ * Al              1      0.00026      0.00051     -0.02190 *
+ * Al              2     -0.01294      0.00911     -0.85448 *
+ * Al              3      0.00841     -0.00790     -1.97622 *
+ * Al              4      0.00036      0.00058     -0.23168 *
+ * Al              5     -0.00052      0.00112     -0.08246 *
+ * Al              6      0.00016      0.00054      0.08495 *
+ * Al              7     -0.01049     -0.02596     -7.29271 *
+ * Al              8      0.00445      0.02077      7.29325 *
+ * Al              9     -0.00063      0.00082      0.02853 *
+ * Al             10      0.00020      0.00074      0.25311 *
+ * Al             11      0.02288     -0.01608      0.85951 *
+ * Al             12      0.00129      0.00999      1.97086 *
+ * Al             13     -0.00054      0.00054     -0.02213 *
+ * Al             14      0.00027     -0.00311     -0.85945 *
+ * Al             15     -0.00314     -0.00644     -1.96940 *
+ * Al             16      0.00008      0.00085     -0.23172 *
+ * Al             17     -0.00066      0.00007     -0.08272 *
+ * Al             18     -0.00009      0.00105      0.08463 *
+ * Al             19     -0.00429      0.00601     -7.29358 *
+ * Al             20      0.01310      0.00647      7.29355 *
+ * Al             21     -0.00049      0.00069      0.02815 *
+ * Al             22      0.00018      0.00050      0.25296 *
+ * Al             23      0.00046     -0.01455      0.86136 *
+ * Al             24      0.00832      0.00296      1.97659 *
+ * Al             25      0.00002      0.00045     -0.02173 *
+ * Al             26      0.00588      0.01028     -0.86388 *
+ * Al             27     -0.00665     -0.00305     -1.97671 *
+ * Al             28     -0.00009      0.00110     -0.23165 *
+ * Al             29     -0.00048      0.00059     -0.08264 *
+ * Al             30      0.00012      0.00023      0.08479 *
+ * Al             31     -0.00238     -0.01148     -7.28948 *
+ * Al             32      0.02741     -0.00549      7.29408 *
+ * Al             33     -0.00010      0.00074      0.02817 *
+ * Al             34      0.00010      0.00068      0.25315 *
+ * Al             35     -0.00039     -0.00085      0.86276 *
+ * Al             36     -0.00569      0.01374      1.98029 *
+ * Al             37      0.00007      0.00024     -0.02214 *
+ * Al             38     -0.01015      0.01361     -0.86430 *
+ * Al             39     -0.00295      0.00172     -1.96588 *
+ * Al             40     -0.00020      0.00046     -0.23130 *
+ * Al             41     -0.00052      0.00024     -0.08267 *
+ * Al             42      0.00022      0.00080      0.08451 *
+ * Al             43     -0.01083     -0.03154     -7.28909 *
+ * Al             44     -0.00641      0.00690      7.29470 *
+ * Al             45     -0.00020      0.00029      0.02849 *
+ * Al             46      0.00024      0.00089      0.25290 *
+ * Al             47      0.02049      0.00442      0.86584 *
+ * Al             48     -0.01253      0.00714      1.97470 *
+ * Al             49     -0.00055      0.00050     -0.02184 *
+ * Al             50     -0.01242     -0.00602     -0.86423 *
+ * Al             51      0.00055     -0.00407     -1.96707 *
+ * Al             52     -0.00027      0.00085     -0.23181 *
+ * Al             53     -0.00063      0.00030     -0.08242 *
+ * Al             54      0.00066      0.00104      0.08480 *
+ * Al             55     -0.00063     -0.01449     -7.29140 *
+ * Al             56      0.01701      0.00913      7.29273 *
+ * Al             57     -0.00009      0.00016      0.02827 *
+ * Al             58      0.00009      0.00091      0.25330 *
+ * Al             59      0.01128      0.00365      0.86150 *
+ * Al             60     -0.00521      0.00017      1.97279 *
+ * Al             61     -0.00019      0.00067     -0.02200 *
+ * Al             62     -0.00261      0.01502     -0.86087 *
+ * Al             63      0.00149      0.00018     -1.97911 *
+ * Al             64     -0.00008      0.00099     -0.23178 *
+ * Al             65     -0.00075      0.00075     -0.08253 *
+ * Al             66      0.00019      0.00017      0.08473 *
+ * Al             67      0.01819      0.00239     -7.29108 *
+ * Al             68      0.00030     -0.00927      7.29233 *
+ * Al             69      0.00022      0.00099      0.02825 *
+ * Al             70     -0.00036      0.00072      0.25278 *
+ * Al             71     -0.01045     -0.00275      0.86290 *
+ * Al             72      0.00226      0.00785      1.98409 *
+ * Al             73     -0.00023      0.00073     -0.02186 *
+ * Al             74      0.00462     -0.00890     -0.86112 *
+ * Al             75      0.00055     -0.00200     -1.97541 *
+ * Al             76     -0.00036      0.00070     -0.23183 *
+ * Al             77     -0.00068      0.00063     -0.08248 *
+ * Al             78     -0.00002      0.00073      0.08482 *
+ * Al             79     -0.02536      0.00467     -7.29042 *
+ * Al             80      0.00401     -0.00494      7.29325 *
+ * Al             81     -0.00012      0.00031      0.02808 *
+ * Al             82     -0.00034      0.00028      0.25310 *
+ * Al             83      0.00415     -0.00536      0.86830 *
+ * Al             84      0.00072      0.00762      1.98505 *
+ * Al             85     -0.00027      0.00036     -0.02178 *
+ * Al             86      0.00408      0.01031     -0.86186 *
+ * Al             87     -0.00516      0.00201     -1.97070 *
+ * Al             88      0.00018      0.00059     -0.23207 *
+ * Al             89     -0.00070      0.00052     -0.08231 *
+ * Al             90      0.00009      0.00064      0.08512 *
+ * Al             91     -0.02697     -0.00144     -7.29060 *
+ * Al             92      0.01041     -0.00821      7.29467 *
+ * Al             93     -0.00017      0.00011      0.02843 *
+ * Al             94      0.00011      0.00025      0.25273 *
+ * Al             95      0.02645      0.00397      0.86172 *
+ * Al             96     -0.00202      0.00291      1.98150 *
+ * Al             97     -0.00029      0.00087     -0.02186 *
+ * Al             98     -0.00759      0.00778     -0.85911 *
+ * Al             99     -0.00316     -0.00488     -1.96650 *
+ * Al            100     -0.00003      0.00106     -0.23151 *
+ * Al            101     -0.00069      0.00072     -0.08218 *
+ * Al            102      0.00000      0.00103      0.08480 *
+ * Al            103     -0.00466     -0.01579     -7.28956 *
+ * Al            104     -0.00233      0.01415      7.29454 *
+ * Al            105     -0.00021      0.00007      0.02845 *
+ * Al            106      0.00007      0.00049      0.25293 *
+ * Al            107      0.01074      0.01382      0.86630 *
+ * Al            108     -0.01139      0.00600      1.98244 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =     14.27 s
+Calculation time    =    123.92 s
+Finalisation time   =      4.25 s
+Total time          =    142.44 s
+Peak Memory Use     = 1607120 kB
+  
+Overall parallel efficiency rating: Terrible (21%)                              
+  
+Data was distributed by:-
+G-vector (1024-way); efficiency rating: Terrible (23%)                          
+k-point (2-way); efficiency rating: Good (77%)                                  
+  
+Parallel notes:
+1) Calculation only took 138.4 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_1nodes_128ranks_1threads_202109031150_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_1nodes_128ranks_1threads_202109031150_mkl.castep
@@ -1,0 +1,871 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 11:45:26 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 128 processes.
+ Data is distributed by G-vector(64-way) and k-point(2-way)
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      485.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                              115.9 MB         0.0 MB |
+| Electronic energy minimisation requirements          81.0 MB         0.0 MB |
+| Force calculation requirements                        3.3 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          681.9 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93881056E+004  0.00000000E+000                         7.52  <-- SCF
+      1  -7.24133231E+004  4.04911021E+000   4.82415463E+001      35.68  <-- SCF
+      2  -7.78242516E+004  1.99533806E+000   2.00404760E+001      56.07  <-- SCF
+      3  -7.79864641E+004  1.80535437E+000   6.00786868E-001      76.49  <-- SCF
+      4  -7.78412676E+004  1.95859791E+000  -5.37764824E-001      99.81  <-- SCF
+      5  -7.77211116E+004  1.34873175E+000  -4.45021993E-001     122.72  <-- SCF
+      6  -7.77152116E+004  1.12173355E+000  -2.18519485E-002     148.00  <-- SCF
+      7  -7.77129481E+004  1.05272514E+000  -8.38337594E-003     170.78  <-- SCF
+      8  -7.77104462E+004  1.02761723E+000  -9.26620045E-003     193.91  <-- SCF
+      9  -7.77084297E+004  9.96411653E-001  -7.46872808E-003     216.80  <-- SCF
+     10  -7.77059729E+004  1.11159090E+000  -9.09932339E-003     239.38  <-- SCF
+     11  -7.77052109E+004  1.16236209E+000  -2.82196285E-003     260.36  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21093039     eV
+Final free energy (E-TS)    =  -77705.21093040     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21093040     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16621      0.02653      0.83811 *
+ * O               2     -0.10177      0.12767      0.83141 *
+ * O               3     -0.06115     -0.15510      0.83910 *
+ * O               4     -0.10355      0.02297      0.38616 *
+ * O               5      0.02235     -0.10160      0.38422 *
+ * O               6      0.07744      0.07662      0.38221 *
+ * O               7     -1.63001      1.73371     -1.01404 *
+ * O               8     -0.69316     -2.29856     -1.02720 *
+ * O               9      2.33602      0.55069     -1.02948 *
+ * O              10      0.09041     -0.01468     -0.39120 *
+ * O              11     -0.02083      0.07720     -0.39231 *
+ * O              12     -0.05752     -0.06393     -0.39420 *
+ * O              13      1.64986     -1.77118      0.95437 *
+ * O              14      0.70805      2.32059      0.96162 *
+ * O              15     -2.37286     -0.55387      0.95936 *
+ * O              16     -0.16949     -0.01155     -0.78589 *
+ * O              17      0.09394     -0.14303     -0.78379 *
+ * O              18      0.07662      0.14784     -0.78674 *
+ * O              19      0.16302      0.02102      0.84546 *
+ * O              20     -0.10388      0.12817      0.84175 *
+ * O              21     -0.06229     -0.15216      0.84129 *
+ * O              22     -0.10213      0.02668      0.38897 *
+ * O              23      0.01666     -0.09804      0.38917 *
+ * O              24      0.07558      0.07538      0.38333 *
+ * O              25     -1.66433      1.77227     -1.02181 *
+ * O              26     -0.71354     -2.34531     -1.01545 *
+ * O              27      2.34471      0.55839     -1.03551 *
+ * O              28      0.08608     -0.01457     -0.38692 *
+ * O              29     -0.02574      0.08311     -0.38883 *
+ * O              30     -0.06086     -0.06317     -0.38845 *
+ * O              31      1.66695     -1.79840      0.95060 *
+ * O              32      0.72416      2.35309      0.95690 *
+ * O              33     -2.35054     -0.54542      0.96179 *
+ * O              34     -0.17160     -0.01330     -0.78541 *
+ * O              35      0.08843     -0.14209     -0.78908 *
+ * O              36      0.07349      0.15301     -0.78915 *
+ * O              37      0.16777      0.02247      0.84726 *
+ * O              38     -0.10388      0.12691      0.84214 *
+ * O              39     -0.05805     -0.15311      0.83857 *
+ * O              40     -0.10385      0.02492      0.38305 *
+ * O              41      0.02287     -0.09984      0.39072 *
+ * O              42      0.07941      0.07455      0.38422 *
+ * O              43     -1.66057      1.77305     -1.01366 *
+ * O              44     -0.68482     -2.28634     -1.02365 *
+ * O              45      2.32084      0.54539     -1.02783 *
+ * O              46      0.08581     -0.01572     -0.38877 *
+ * O              47     -0.02118      0.08447     -0.39649 *
+ * O              48     -0.05903     -0.06248     -0.39338 *
+ * O              49      1.64067     -1.76130      0.96670 *
+ * O              50      0.71012      2.32287      0.95546 *
+ * O              51     -2.31729     -0.54433      0.96854 *
+ * O              52     -0.17197     -0.01557     -0.80172 *
+ * O              53      0.09657     -0.14226     -0.78635 *
+ * O              54      0.07742      0.15751     -0.78219 *
+ * O              55      0.16390      0.02033      0.84788 *
+ * O              56     -0.10110      0.12491      0.83826 *
+ * O              57     -0.06021     -0.15079      0.84027 *
+ * O              58     -0.10166      0.01999      0.38628 *
+ * O              59      0.02596     -0.09872      0.38875 *
+ * O              60      0.07677      0.07399      0.38235 *
+ * O              61     -1.67032      1.77341     -1.00859 *
+ * O              62     -0.67760     -2.27442     -1.02111 *
+ * O              63      2.35579      0.55353     -1.02504 *
+ * O              64      0.08497     -0.01749     -0.38543 *
+ * O              65     -0.02250      0.07420     -0.39510 *
+ * O              66     -0.05957     -0.05995     -0.39583 *
+ * O              67      1.64987     -1.76440      0.96202 *
+ * O              68      0.70664      2.32619      0.96750 *
+ * O              69     -2.35591     -0.55108      0.96864 *
+ * O              70     -0.17442     -0.00707     -0.78954 *
+ * O              71      0.09302     -0.14062     -0.78500 *
+ * O              72      0.07319      0.14719     -0.78326 *
+ * O              73      0.15900      0.01832      0.83856 *
+ * O              74     -0.09997      0.12942      0.83999 *
+ * O              75     -0.06233     -0.15168      0.83856 *
+ * O              76     -0.10024      0.02551      0.38120 *
+ * O              77      0.02256     -0.09350      0.38370 *
+ * O              78      0.08313      0.06748      0.39295 *
+ * O              79     -1.64194      1.74392     -1.02326 *
+ * O              80     -0.69643     -2.29673     -1.02843 *
+ * O              81      2.32239      0.54841     -1.03489 *
+ * O              82      0.08204     -0.01409     -0.39488 *
+ * O              83     -0.01425      0.07849     -0.39563 *
+ * O              84     -0.06140     -0.06481     -0.38975 *
+ * O              85      1.65144     -1.78436      0.95001 *
+ * O              86      0.69320      2.28559      0.96909 *
+ * O              87     -2.33944     -0.54118      0.96933 *
+ * O              88     -0.17156     -0.01481     -0.78411 *
+ * O              89      0.09480     -0.14100     -0.78224 *
+ * O              90      0.06990      0.14752     -0.77861 *
+ * O              91      0.16771      0.02150      0.84529 *
+ * O              92     -0.10428      0.13079      0.83078 *
+ * O              93     -0.05912     -0.14839      0.84177 *
+ * O              94     -0.09839      0.02432      0.38796 *
+ * O              95      0.02174     -0.09908      0.38620 *
+ * O              96      0.07951      0.07358      0.38405 *
+ * O              97     -1.67649      1.78291     -1.01487 *
+ * O              98     -0.70099     -2.32920     -1.02724 *
+ * O              99      2.34766      0.55672     -1.02304 *
+ * O             100      0.08666     -0.01187     -0.38985 *
+ * O             101     -0.02200      0.08231     -0.39833 *
+ * O             102     -0.05928     -0.06084     -0.39109 *
+ * O             103      1.67105     -1.79091      0.96130 *
+ * O             104      0.70316      2.32138      0.96797 *
+ * O             105     -2.36119     -0.54499      0.96166 *
+ * O             106     -0.17802     -0.00974     -0.79025 *
+ * O             107      0.09041     -0.14381     -0.78235 *
+ * O             108      0.07780      0.15037     -0.78196 *
+ * O             109      0.16708      0.01453      0.84024 *
+ * O             110     -0.10917      0.13019      0.83031 *
+ * O             111     -0.06431     -0.15052      0.84002 *
+ * O             112     -0.10020      0.02365      0.38273 *
+ * O             113      0.02657     -0.09687      0.38184 *
+ * O             114      0.07662      0.07333      0.38585 *
+ * O             115     -1.67860      1.77994     -1.01419 *
+ * O             116     -0.67912     -2.28673     -1.01872 *
+ * O             117      2.33993      0.55168     -1.02102 *
+ * O             118      0.08530     -0.01822     -0.38988 *
+ * O             119     -0.02071      0.08119     -0.39319 *
+ * O             120     -0.05643     -0.06308     -0.38429 *
+ * O             121      1.65322     -1.77208      0.95406 *
+ * O             122      0.71836      2.33750      0.95345 *
+ * O             123     -2.35222     -0.54754      0.96704 *
+ * O             124     -0.17749     -0.01014     -0.78767 *
+ * O             125      0.09600     -0.13934     -0.78533 *
+ * O             126      0.07330      0.14794     -0.78733 *
+ * O             127      0.16569      0.02249      0.84263 *
+ * O             128     -0.10465      0.11997      0.84010 *
+ * O             129     -0.06191     -0.15002      0.83203 *
+ * O             130     -0.10223      0.02693      0.38394 *
+ * O             131      0.02387     -0.10266      0.38530 *
+ * O             132      0.07560      0.07167      0.38713 *
+ * O             133     -1.65983      1.76485     -1.01820 *
+ * O             134     -0.69340     -2.30243     -1.03106 *
+ * O             135      2.34233      0.55306     -1.02691 *
+ * O             136      0.08209     -0.01941     -0.39278 *
+ * O             137     -0.02315      0.08217     -0.39096 *
+ * O             138     -0.05488     -0.06348     -0.39273 *
+ * O             139      1.64244     -1.76522      0.96164 *
+ * O             140      0.70519      2.31633      0.95736 *
+ * O             141     -2.34418     -0.54508      0.96783 *
+ * O             142     -0.17045     -0.01035     -0.78978 *
+ * O             143      0.09434     -0.14344     -0.77862 *
+ * O             144      0.07562      0.15079     -0.78275 *
+ * O             145      0.16270      0.02326      0.84460 *
+ * O             146     -0.10144      0.12797      0.83921 *
+ * O             147     -0.06229     -0.14740      0.83614 *
+ * O             148     -0.10028      0.02909      0.38743 *
+ * O             149      0.02512     -0.09638      0.38642 *
+ * O             150      0.07870      0.07369      0.38721 *
+ * O             151     -1.66595      1.76756     -1.02043 *
+ * O             152     -0.69581     -2.31614     -1.02418 *
+ * O             153      2.35492      0.55316     -1.03043 *
+ * O             154      0.08564     -0.01625     -0.39002 *
+ * O             155     -0.02331      0.08092     -0.39077 *
+ * O             156     -0.05789     -0.06382     -0.39129 *
+ * O             157      1.66055     -1.78589      0.95289 *
+ * O             158      0.69341      2.27608      0.96873 *
+ * O             159     -2.37480     -0.54086      0.95207 *
+ * O             160     -0.17106     -0.01635     -0.78764 *
+ * O             161      0.09942     -0.14117     -0.78261 *
+ * O             162      0.07297      0.15065     -0.79144 *
+ * Al              1      0.00022     -0.00110     -0.02072 *
+ * Al              2      0.00190      0.01149     -0.86940 *
+ * Al              3     -0.00500     -0.00013     -1.97827 *
+ * Al              4      0.00043     -0.00014     -0.23075 *
+ * Al              5     -0.00002     -0.00096     -0.08320 *
+ * Al              6      0.00052     -0.00053      0.08476 *
+ * Al              7      0.00433      0.00273     -7.29036 *
+ * Al              8     -0.01562     -0.02322      7.29261 *
+ * Al              9      0.00033     -0.00059      0.02753 *
+ * Al             10      0.00016     -0.00052      0.25180 *
+ * Al             11      0.00376     -0.00017      0.85614 *
+ * Al             12      0.00220      0.00050      1.97669 *
+ * Al             13      0.00023     -0.00027     -0.02124 *
+ * Al             14     -0.00862     -0.00477     -0.86012 *
+ * Al             15      0.00349      0.00460     -1.96160 *
+ * Al             16     -0.00007     -0.00089     -0.23104 *
+ * Al             17     -0.00040     -0.00089     -0.08273 *
+ * Al             18      0.00014     -0.00060      0.08519 *
+ * Al             19      0.01014     -0.01665     -7.29042 *
+ * Al             20      0.01051      0.01676      7.29401 *
+ * Al             21      0.00001     -0.00065      0.02684 *
+ * Al             22      0.00042      0.00009      0.25199 *
+ * Al             23      0.00062      0.00480      0.86559 *
+ * Al             24     -0.00698     -0.00893      1.96895 *
+ * Al             25      0.00027     -0.00045     -0.02085 *
+ * Al             26     -0.00709     -0.00473     -0.85674 *
+ * Al             27      0.00890     -0.00642     -1.97610 *
+ * Al             28     -0.00001     -0.00072     -0.23082 *
+ * Al             29     -0.00033     -0.00064     -0.08285 *
+ * Al             30      0.00028     -0.00081      0.08453 *
+ * Al             31      0.02131      0.01488     -7.28989 *
+ * Al             32      0.00561      0.01259      7.29194 *
+ * Al             33      0.00085     -0.00112      0.02680 *
+ * Al             34     -0.00014     -0.00092      0.25199 *
+ * Al             35     -0.01512      0.02046      0.86297 *
+ * Al             36     -0.00483     -0.00770      1.98478 *
+ * Al             37      0.00021     -0.00089     -0.02055 *
+ * Al             38     -0.01324     -0.01218     -0.86130 *
+ * Al             39      0.00484     -0.01283     -1.97198 *
+ * Al             40      0.00040     -0.00055     -0.23132 *
+ * Al             41     -0.00005     -0.00051     -0.08259 *
+ * Al             42      0.00065     -0.00130      0.08501 *
+ * Al             43      0.00318      0.00169     -7.29140 *
+ * Al             44      0.00189      0.01501      7.29172 *
+ * Al             45      0.00037     -0.00090      0.02672 *
+ * Al             46      0.00012     -0.00067      0.25138 *
+ * Al             47     -0.00400     -0.00135      0.86494 *
+ * Al             48      0.00074     -0.00187      1.97936 *
+ * Al             49      0.00020     -0.00121     -0.02113 *
+ * Al             50      0.01480     -0.00634     -0.85597 *
+ * Al             51      0.00084      0.00027     -1.97634 *
+ * Al             52      0.00050     -0.00040     -0.23085 *
+ * Al             53      0.00010     -0.00066     -0.08251 *
+ * Al             54      0.00051     -0.00069      0.08459 *
+ * Al             55      0.00663     -0.00893     -7.28985 *
+ * Al             56     -0.00552     -0.00996      7.29424 *
+ * Al             57      0.00063     -0.00102      0.02721 *
+ * Al             58      0.00007     -0.00030      0.25183 *
+ * Al             59     -0.00032      0.00715      0.86635 *
+ * Al             60     -0.00733      0.00564      1.98478 *
+ * Al             61      0.00008     -0.00099     -0.02103 *
+ * Al             62     -0.01846     -0.00026     -0.85944 *
+ * Al             63      0.00708     -0.00082     -1.96342 *
+ * Al             64      0.00023     -0.00056     -0.23059 *
+ * Al             65     -0.00037     -0.00080     -0.08287 *
+ * Al             66      0.00049     -0.00089      0.08499 *
+ * Al             67     -0.01759     -0.02179     -7.28975 *
+ * Al             68      0.00508      0.03258      7.29389 *
+ * Al             69     -0.00044     -0.00135      0.02679 *
+ * Al             70      0.00090     -0.00002      0.25187 *
+ * Al             71      0.01791     -0.00075      0.86602 *
+ * Al             72     -0.00701      0.00150      1.97441 *
+ * Al             73      0.00015     -0.00043     -0.02117 *
+ * Al             74     -0.02452      0.00084     -0.86197 *
+ * Al             75      0.00846     -0.00918     -1.97144 *
+ * Al             76      0.00029     -0.00067     -0.23111 *
+ * Al             77     -0.00030     -0.00094     -0.08260 *
+ * Al             78      0.00037     -0.00093      0.08499 *
+ * Al             79     -0.02364     -0.01095     -7.29180 *
+ * Al             80      0.00638      0.01794      7.29191 *
+ * Al             81     -0.00023     -0.00082      0.02675 *
+ * Al             82      0.00035     -0.00088      0.25152 *
+ * Al             83      0.02400     -0.00375      0.86645 *
+ * Al             84     -0.00055     -0.00515      1.97525 *
+ * Al             85     -0.00015     -0.00117     -0.02122 *
+ * Al             86     -0.00449      0.00179     -0.85834 *
+ * Al             87      0.00268     -0.00391     -1.97119 *
+ * Al             88      0.00016     -0.00092     -0.23068 *
+ * Al             89      0.00030     -0.00100     -0.08269 *
+ * Al             90      0.00022     -0.00056      0.08505 *
+ * Al             91      0.01528      0.00716     -7.29120 *
+ * Al             92     -0.00592      0.00715      7.29385 *
+ * Al             93     -0.00007     -0.00071      0.02653 *
+ * Al             94      0.00038     -0.00087      0.25156 *
+ * Al             95     -0.00820      0.00709      0.86245 *
+ * Al             96     -0.00092     -0.00272      1.98175 *
+ * Al             97     -0.00013     -0.00074     -0.02089 *
+ * Al             98     -0.00116     -0.01206     -0.85692 *
+ * Al             99      0.00336     -0.00332     -1.96743 *
+ * Al            100      0.00033     -0.00079     -0.23041 *
+ * Al            101     -0.00024     -0.00115     -0.08307 *
+ * Al            102      0.00064     -0.00061      0.08427 *
+ * Al            103      0.01676     -0.01735     -7.29068 *
+ * Al            104      0.00966      0.01783      7.29412 *
+ * Al            105      0.00060     -0.00137      0.02685 *
+ * Al            106      0.00004     -0.00083      0.25183 *
+ * Al            107      0.00484     -0.00276      0.85883 *
+ * Al            108     -0.00180      0.01267      1.98009 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      6.17 s
+Calculation time    =    276.79 s
+Finalisation time   =      1.75 s
+Total time          =    284.71 s
+Peak Memory Use     = 1160876 kB
+  
+Overall parallel efficiency rating: Satisfactory (66%)                          
+  
+Data was distributed by:-
+G-vector (64-way); efficiency rating: Satisfactory (68%)                        
+k-point (2-way); efficiency rating: Excellent (96%)                             
+  
+Parallel notes:
+1) Calculation only took 283.3 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_202109031314_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_202109031314_mkl.castep
@@ -1,0 +1,871 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:11:49 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 256 processes.
+ Data is distributed by G-vector(128-way) and k-point(2-way)
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      490.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               71.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          45.2 MB         0.0 MB |
+| Force calculation requirements                        1.7 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          606.8 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93903962E+004  0.00000000E+000                         3.41  <-- SCF
+      1  -7.24025078E+004  4.04952038E+000   4.81930060E+001      22.14  <-- SCF
+      2  -7.78252467E+004  1.95718735E+000   2.00842181E+001      35.40  <-- SCF
+      3  -7.79864690E+004  1.80210546E+000   5.97119548E-001      48.61  <-- SCF
+      4  -7.78412511E+004  1.95866797E+000  -5.37843840E-001      63.76  <-- SCF
+      5  -7.77211110E+004  1.34858550E+000  -4.44963492E-001      78.77  <-- SCF
+      6  -7.77152160E+004  1.12181373E+000  -2.18332198E-002      94.85  <-- SCF
+      7  -7.77129479E+004  1.05270612E+000  -8.40047628E-003     109.58  <-- SCF
+      8  -7.77104474E+004  1.02757566E+000  -9.26117241E-003     124.27  <-- SCF
+      9  -7.77084302E+004  9.96440502E-001  -7.47088452E-003     138.98  <-- SCF
+     10  -7.77059868E+004  1.11158438E+000  -9.04964606E-003     153.36  <-- SCF
+     11  -7.77052160E+004  1.16142631E+000  -2.85493552E-003     166.74  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21598074     eV
+Final free energy (E-TS)    =  -77705.21598075     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21598074     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16546      0.02416      0.81294 *
+ * O               2     -0.09616      0.12867      0.80709 *
+ * O               3     -0.06588     -0.14994      0.81406 *
+ * O               4     -0.10281      0.02695      0.37080 *
+ * O               5      0.02296     -0.10533      0.37258 *
+ * O               6      0.08183      0.07481      0.36653 *
+ * O               7     -1.64065      1.74452     -1.02151 *
+ * O               8     -0.69944     -2.30209     -1.02675 *
+ * O               9      2.35342      0.54882     -1.03858 *
+ * O              10      0.08666     -0.01690     -0.37847 *
+ * O              11     -0.02365      0.08637     -0.38175 *
+ * O              12     -0.06099     -0.06281     -0.37824 *
+ * O              13      1.64860     -1.77868      0.96839 *
+ * O              14      0.68951      2.28569      0.96500 *
+ * O              15     -2.33669     -0.53356      0.96999 *
+ * O              16     -0.17547     -0.00725     -0.76416 *
+ * O              17      0.09752     -0.14298     -0.75951 *
+ * O              18      0.07425      0.15725     -0.76225 *
+ * O              19      0.16803      0.01920      0.82015 *
+ * O              20     -0.10362      0.12991      0.81354 *
+ * O              21     -0.06580     -0.14472      0.81601 *
+ * O              22     -0.10143      0.02835      0.36943 *
+ * O              23      0.02263     -0.10179      0.36864 *
+ * O              24      0.07665      0.07523      0.36866 *
+ * O              25     -1.66701      1.77075     -1.03492 *
+ * O              26     -0.68684     -2.29542     -1.03275 *
+ * O              27      2.35749      0.55462     -1.04283 *
+ * O              28      0.08133     -0.01980     -0.37850 *
+ * O              29     -0.02038      0.07898     -0.37860 *
+ * O              30     -0.06232     -0.06315     -0.37473 *
+ * O              31      1.66467     -1.78624      0.98469 *
+ * O              32      0.69482      2.29819      0.97034 *
+ * O              33     -2.34814     -0.54040      0.97956 *
+ * O              34     -0.17813     -0.00834     -0.76088 *
+ * O              35      0.09778     -0.14689     -0.76193 *
+ * O              36      0.07469      0.14838     -0.75826 *
+ * O              37      0.16990      0.01744      0.81425 *
+ * O              38     -0.10322      0.13320      0.81620 *
+ * O              39     -0.06402     -0.14920      0.80926 *
+ * O              40     -0.10523      0.02895      0.36732 *
+ * O              41      0.02687     -0.10466      0.37168 *
+ * O              42      0.07885      0.07157      0.36777 *
+ * O              43     -1.65142      1.75208     -1.02511 *
+ * O              44     -0.67866     -2.26635     -1.02038 *
+ * O              45      2.32009      0.54255     -1.03354 *
+ * O              46      0.08567     -0.01931     -0.37815 *
+ * O              47     -0.02418      0.08385     -0.37607 *
+ * O              48     -0.06439     -0.07142     -0.37582 *
+ * O              49      1.65950     -1.78526      0.97844 *
+ * O              50      0.71527      2.33420      0.97835 *
+ * O              51     -2.35868     -0.55374      0.98680 *
+ * O              52     -0.18085     -0.00531     -0.76635 *
+ * O              53      0.08977     -0.14089     -0.75906 *
+ * O              54      0.07611      0.15385     -0.75937 *
+ * O              55      0.16552      0.02106      0.81218 *
+ * O              56     -0.09856      0.13065      0.81277 *
+ * O              57     -0.06654     -0.14702      0.81294 *
+ * O              58     -0.10475      0.02844      0.36868 *
+ * O              59      0.01967     -0.10042      0.36962 *
+ * O              60      0.07989      0.07861      0.37000 *
+ * O              61     -1.65968      1.75848     -1.03018 *
+ * O              62     -0.68769     -2.30129     -1.03344 *
+ * O              63      2.35685      0.55275     -1.03609 *
+ * O              64      0.08668     -0.02116     -0.37511 *
+ * O              65     -0.02570      0.08176     -0.37275 *
+ * O              66     -0.05911     -0.06669     -0.37544 *
+ * O              67      1.65481     -1.78908      0.96737 *
+ * O              68      0.71009      2.32141      0.98285 *
+ * O              69     -2.31933     -0.54483      0.96963 *
+ * O              70     -0.17787     -0.00847     -0.76529 *
+ * O              71      0.09221     -0.14549     -0.76050 *
+ * O              72      0.06899      0.15308     -0.75638 *
+ * O              73      0.16702      0.01837      0.81739 *
+ * O              74     -0.10637      0.12860      0.81480 *
+ * O              75     -0.06197     -0.14239      0.80796 *
+ * O              76     -0.10208      0.02283      0.37012 *
+ * O              77      0.02311     -0.09999      0.36896 *
+ * O              78      0.08211      0.07316      0.36810 *
+ * O              79     -1.66020      1.76919     -1.03916 *
+ * O              80     -0.67806     -2.27901     -1.02993 *
+ * O              81      2.33916      0.54795     -1.03526 *
+ * O              82      0.08936     -0.02147     -0.37745 *
+ * O              83     -0.02639      0.08276     -0.37780 *
+ * O              84     -0.06329     -0.06518     -0.36829 *
+ * O              85      1.65560     -1.78969      0.96722 *
+ * O              86      0.70254      2.30598      0.97685 *
+ * O              87     -2.34465     -0.54666      0.96698 *
+ * O              88     -0.17293     -0.00848     -0.76817 *
+ * O              89      0.09630     -0.14464     -0.75764 *
+ * O              90      0.07138      0.15107     -0.75894 *
+ * O              91      0.16735      0.01663      0.82123 *
+ * O              92     -0.10911      0.13678      0.81157 *
+ * O              93     -0.06170     -0.15214      0.81698 *
+ * O              94     -0.10212      0.02481      0.36797 *
+ * O              95      0.02111     -0.10135      0.36935 *
+ * O              96      0.07746      0.07536      0.36864 *
+ * O              97     -1.66988      1.78799     -1.03528 *
+ * O              98     -0.66620     -2.27077     -1.03039 *
+ * O              99      2.32370      0.54669     -1.03516 *
+ * O             100      0.08858     -0.01767     -0.37297 *
+ * O             101     -0.02631      0.08071     -0.38044 *
+ * O             102     -0.06074     -0.06512     -0.37196 *
+ * O             103      1.66071     -1.78210      0.97030 *
+ * O             104      0.70311      2.31046      0.97547 *
+ * O             105     -2.37508     -0.55130      0.98659 *
+ * O             106     -0.17525     -0.00607     -0.76032 *
+ * O             107      0.09430     -0.14549     -0.76220 *
+ * O             108      0.07652      0.15240     -0.76702 *
+ * O             109      0.16770      0.02197      0.81295 *
+ * O             110     -0.10397      0.12921      0.81519 *
+ * O             111     -0.06285     -0.15522      0.81006 *
+ * O             112     -0.10382      0.02365      0.37140 *
+ * O             113      0.02148     -0.10270      0.37550 *
+ * O             114      0.08026      0.07652      0.36248 *
+ * O             115     -1.65021      1.75632     -1.02690 *
+ * O             116     -0.70342     -2.31655     -1.03751 *
+ * O             117      2.33268      0.55807     -1.03652 *
+ * O             118      0.08556     -0.01931     -0.37638 *
+ * O             119     -0.02034      0.07755     -0.38030 *
+ * O             120     -0.06360     -0.06058     -0.37443 *
+ * O             121      1.66643     -1.80035      0.97018 *
+ * O             122      0.68999      2.29754      0.96803 *
+ * O             123     -2.34524     -0.53677      0.97302 *
+ * O             124     -0.17507     -0.01129     -0.75964 *
+ * O             125      0.09898     -0.14420     -0.75595 *
+ * O             126      0.07415      0.14959     -0.75966 *
+ * O             127      0.16525      0.02368      0.81186 *
+ * O             128     -0.10479      0.13126      0.80929 *
+ * O             129     -0.06465     -0.15763      0.81518 *
+ * O             130     -0.10227      0.02545      0.37047 *
+ * O             131      0.01998     -0.09627      0.37630 *
+ * O             132      0.08079      0.07477      0.36651 *
+ * O             133     -1.64940      1.74972     -1.02330 *
+ * O             134     -0.69023     -2.29459     -1.03307 *
+ * O             135      2.34930      0.55350     -1.02752 *
+ * O             136      0.08386     -0.01598     -0.37672 *
+ * O             137     -0.02294      0.08197     -0.37920 *
+ * O             138     -0.06341     -0.06418     -0.37632 *
+ * O             139      1.65271     -1.78630      0.96586 *
+ * O             140      0.70847      2.31134      0.97245 *
+ * O             141     -2.32936     -0.54124      0.97518 *
+ * O             142     -0.17634     -0.00981     -0.76434 *
+ * O             143      0.09137     -0.14797     -0.75737 *
+ * O             144      0.07406      0.15113     -0.75596 *
+ * O             145      0.16638      0.01935      0.82375 *
+ * O             146     -0.10430      0.12987      0.81009 *
+ * O             147     -0.06201     -0.15279      0.81788 *
+ * O             148     -0.10736      0.02817      0.36977 *
+ * O             149      0.01937     -0.10353      0.37244 *
+ * O             150      0.08096      0.07919      0.36409 *
+ * O             151     -1.67022      1.77885     -1.03871 *
+ * O             152     -0.69352     -2.30889     -1.03448 *
+ * O             153      2.34004      0.55637     -1.03928 *
+ * O             154      0.08674     -0.02108     -0.37915 *
+ * O             155     -0.02409      0.08379     -0.37762 *
+ * O             156     -0.06030     -0.06568     -0.37517 *
+ * O             157      1.63441     -1.76513      0.96626 *
+ * O             158      0.70166      2.29769      0.97129 *
+ * O             159     -2.33831     -0.54053      0.97307 *
+ * O             160     -0.17590     -0.01411     -0.76733 *
+ * O             161      0.09602     -0.14378     -0.75459 *
+ * O             162      0.07671      0.15656     -0.75454 *
+ * Al              1     -0.00078     -0.00043     -0.04369 *
+ * Al              2      0.00926     -0.00399     -0.87355 *
+ * Al              3     -0.00637     -0.00298     -1.98218 *
+ * Al              4     -0.00020     -0.00010     -0.25108 *
+ * Al              5     -0.00120     -0.00024     -0.08070 *
+ * Al              6      0.00003     -0.00014      0.08247 *
+ * Al              7      0.03002     -0.01215     -7.29639 *
+ * Al              8      0.00646     -0.00218      7.29946 *
+ * Al              9     -0.00076     -0.00054      0.05061 *
+ * Al             10     -0.00071      0.00022      0.27267 *
+ * Al             11     -0.00823      0.01285      0.87455 *
+ * Al             12     -0.00885      0.00687      1.99500 *
+ * Al             13     -0.00049      0.00005     -0.04377 *
+ * Al             14     -0.01552     -0.00249     -0.87068 *
+ * Al             15      0.00087     -0.01006     -1.97477 *
+ * Al             16     -0.00062      0.00001     -0.25146 *
+ * Al             17     -0.00111     -0.00029     -0.08042 *
+ * Al             18     -0.00080     -0.00017      0.08222 *
+ * Al             19     -0.00509     -0.03543     -7.29645 *
+ * Al             20      0.02396      0.02835      7.29835 *
+ * Al             21     -0.00072     -0.00021      0.04990 *
+ * Al             22     -0.00050     -0.00007      0.27267 *
+ * Al             23      0.02522      0.00225      0.87336 *
+ * Al             24     -0.00862      0.00815      1.98594 *
+ * Al             25     -0.00077     -0.00045     -0.04390 *
+ * Al             26     -0.00271      0.00076     -0.86818 *
+ * Al             27      0.00439     -0.00935     -1.99067 *
+ * Al             28     -0.00035      0.00006     -0.25129 *
+ * Al             29     -0.00115     -0.00040     -0.08057 *
+ * Al             30     -0.00018     -0.00020      0.08239 *
+ * Al             31     -0.02118     -0.01098     -7.29790 *
+ * Al             32     -0.00018      0.00968      7.29821 *
+ * Al             33     -0.00083     -0.00034      0.05065 *
+ * Al             34     -0.00053      0.00028      0.27314 *
+ * Al             35      0.01159     -0.00273      0.87343 *
+ * Al             36     -0.00366     -0.00221      1.97997 *
+ * Al             37     -0.00045      0.00035     -0.04412 *
+ * Al             38     -0.00904     -0.00690     -0.87351 *
+ * Al             39     -0.00145     -0.00690     -1.97769 *
+ * Al             40     -0.00085     -0.00016     -0.25208 *
+ * Al             41     -0.00129     -0.00044     -0.08077 *
+ * Al             42     -0.00045     -0.00034      0.08224 *
+ * Al             43      0.00410     -0.01786     -7.29639 *
+ * Al             44      0.02573      0.01542      7.29844 *
+ * Al             45     -0.00070     -0.00057      0.05013 *
+ * Al             46     -0.00036      0.00008      0.27287 *
+ * Al             47      0.00883      0.01632      0.87882 *
+ * Al             48     -0.01272     -0.00637      1.98656 *
+ * Al             49     -0.00038     -0.00033     -0.04452 *
+ * Al             50     -0.01665      0.00590     -0.86546 *
+ * Al             51      0.00572     -0.01113     -1.98258 *
+ * Al             52     -0.00081     -0.00003     -0.25146 *
+ * Al             53     -0.00062     -0.00018     -0.08061 *
+ * Al             54     -0.00040     -0.00020      0.08231 *
+ * Al             55      0.02393     -0.01478     -7.29675 *
+ * Al             56      0.03001      0.02566      7.29862 *
+ * Al             57     -0.00065     -0.00042      0.05014 *
+ * Al             58     -0.00048     -0.00006      0.27288 *
+ * Al             59     -0.00118      0.01578      0.87015 *
+ * Al             60     -0.01039      0.00217      1.98744 *
+ * Al             61     -0.00055     -0.00024     -0.04389 *
+ * Al             62     -0.03206      0.01001     -0.86646 *
+ * Al             63      0.01268     -0.01222     -1.98330 *
+ * Al             64      0.00010     -0.00003     -0.25147 *
+ * Al             65     -0.00104     -0.00031     -0.08071 *
+ * Al             66     -0.00010     -0.00023      0.08232 *
+ * Al             67      0.00360     -0.01448     -7.29741 *
+ * Al             68     -0.00408      0.03647      7.29786 *
+ * Al             69     -0.00072     -0.00039      0.05038 *
+ * Al             70     -0.00022     -0.00019      0.27280 *
+ * Al             71      0.01301     -0.00398      0.86429 *
+ * Al             72     -0.00020      0.00619      1.98180 *
+ * Al             73     -0.00149     -0.00029     -0.04385 *
+ * Al             74     -0.00710     -0.00615     -0.87802 *
+ * Al             75      0.00071      0.00306     -1.97929 *
+ * Al             76     -0.00102      0.00046     -0.25137 *
+ * Al             77     -0.00124     -0.00045     -0.08055 *
+ * Al             78     -0.00027      0.00033      0.08279 *
+ * Al             79      0.00570     -0.03329     -7.29560 *
+ * Al             80      0.01587      0.00295      7.29848 *
+ * Al             81     -0.00081     -0.00046      0.05017 *
+ * Al             82     -0.00094     -0.00022      0.27293 *
+ * Al             83      0.01047      0.00515      0.87591 *
+ * Al             84     -0.01200      0.00939      1.98706 *
+ * Al             85     -0.00056     -0.00027     -0.04383 *
+ * Al             86     -0.00974      0.01498     -0.87595 *
+ * Al             87     -0.00294     -0.00439     -1.98352 *
+ * Al             88     -0.00051     -0.00000     -0.25120 *
+ * Al             89     -0.00117     -0.00046     -0.08056 *
+ * Al             90     -0.00093     -0.00020      0.08261 *
+ * Al             91     -0.01021     -0.01956     -7.29632 *
+ * Al             92     -0.00386     -0.00232      7.29874 *
+ * Al             93     -0.00050     -0.00027      0.04968 *
+ * Al             94     -0.00055     -0.00008      0.27253 *
+ * Al             95      0.01620      0.00799      0.87912 *
+ * Al             96     -0.00911     -0.00067      1.98860 *
+ * Al             97     -0.00080     -0.00027     -0.04371 *
+ * Al             98     -0.02463      0.00092     -0.87414 *
+ * Al             99      0.00658     -0.00166     -1.97613 *
+ * Al            100     -0.00040     -0.00062     -0.25166 *
+ * Al            101     -0.00141     -0.00018     -0.08041 *
+ * Al            102     -0.00053     -0.00013      0.08256 *
+ * Al            103     -0.00222      0.00384     -7.29675 *
+ * Al            104     -0.01906      0.01852      7.29852 *
+ * Al            105     -0.00048     -0.00059      0.05006 *
+ * Al            106     -0.00045     -0.00066      0.27289 *
+ * Al            107      0.00856      0.01037      0.87084 *
+ * Al            108     -0.00299      0.00157      1.99364 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.58 s
+Calculation time    =    176.11 s
+Finalisation time   =      1.78 s
+Total time          =    180.47 s
+Peak Memory Use     = 1296584 kB
+  
+Overall parallel efficiency rating: Mediocre (55%)                              
+  
+Data was distributed by:-
+G-vector (128-way); efficiency rating: Mediocre (57%)                           
+k-point (2-way); efficiency rating: Excellent (96%)                             
+  
+Parallel notes:
+1) Calculation only took 179.0 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_4smp_202109031204_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_4smp_202109031204_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 12:01:21 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 256 processes.
+ Data is distributed by G-vector(128-way) and k-point(2-way)
+ G-vector communication optimised for up to 4-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          4
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      493.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               71.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          45.2 MB         0.0 MB |
+| Force calculation requirements                        1.7 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          609.8 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93903962E+004  0.00000000E+000                         3.81  <-- SCF
+      1  -7.24025078E+004  4.04952038E+000   4.81930060E+001      23.22  <-- SCF
+      2  -7.78252467E+004  1.95718735E+000   2.00842181E+001      37.39  <-- SCF
+      3  -7.79864690E+004  1.80210546E+000   5.97119548E-001      51.70  <-- SCF
+      4  -7.78412511E+004  1.95866797E+000  -5.37843840E-001      68.11  <-- SCF
+      5  -7.77211110E+004  1.34858550E+000  -4.44963492E-001      84.75  <-- SCF
+      6  -7.77152160E+004  1.12181373E+000  -2.18332198E-002     102.27  <-- SCF
+      7  -7.77129479E+004  1.05270612E+000  -8.40047628E-003     118.26  <-- SCF
+      8  -7.77104474E+004  1.02757566E+000  -9.26117241E-003     134.53  <-- SCF
+      9  -7.77084302E+004  9.96440502E-001  -7.47088452E-003     150.24  <-- SCF
+     10  -7.77059868E+004  1.11158438E+000  -9.04964606E-003     165.88  <-- SCF
+     11  -7.77052160E+004  1.16142631E+000  -2.85493552E-003     180.37  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21598074     eV
+Final free energy (E-TS)    =  -77705.21598074     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21598074     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16546      0.02416      0.81294 *
+ * O               2     -0.09616      0.12867      0.80709 *
+ * O               3     -0.06588     -0.14994      0.81406 *
+ * O               4     -0.10281      0.02695      0.37080 *
+ * O               5      0.02296     -0.10533      0.37258 *
+ * O               6      0.08183      0.07481      0.36653 *
+ * O               7     -1.64065      1.74452     -1.02151 *
+ * O               8     -0.69944     -2.30209     -1.02675 *
+ * O               9      2.35342      0.54882     -1.03858 *
+ * O              10      0.08666     -0.01690     -0.37847 *
+ * O              11     -0.02365      0.08637     -0.38175 *
+ * O              12     -0.06099     -0.06281     -0.37824 *
+ * O              13      1.64860     -1.77868      0.96839 *
+ * O              14      0.68951      2.28569      0.96500 *
+ * O              15     -2.33669     -0.53356      0.96999 *
+ * O              16     -0.17547     -0.00725     -0.76416 *
+ * O              17      0.09752     -0.14298     -0.75951 *
+ * O              18      0.07425      0.15725     -0.76225 *
+ * O              19      0.16803      0.01920      0.82015 *
+ * O              20     -0.10362      0.12991      0.81354 *
+ * O              21     -0.06580     -0.14472      0.81601 *
+ * O              22     -0.10143      0.02835      0.36943 *
+ * O              23      0.02263     -0.10179      0.36864 *
+ * O              24      0.07665      0.07523      0.36866 *
+ * O              25     -1.66701      1.77075     -1.03492 *
+ * O              26     -0.68684     -2.29542     -1.03275 *
+ * O              27      2.35749      0.55462     -1.04283 *
+ * O              28      0.08133     -0.01980     -0.37850 *
+ * O              29     -0.02038      0.07898     -0.37860 *
+ * O              30     -0.06232     -0.06315     -0.37473 *
+ * O              31      1.66467     -1.78624      0.98469 *
+ * O              32      0.69482      2.29819      0.97034 *
+ * O              33     -2.34814     -0.54040      0.97956 *
+ * O              34     -0.17813     -0.00834     -0.76088 *
+ * O              35      0.09778     -0.14689     -0.76193 *
+ * O              36      0.07469      0.14838     -0.75826 *
+ * O              37      0.16990      0.01744      0.81425 *
+ * O              38     -0.10322      0.13320      0.81620 *
+ * O              39     -0.06402     -0.14920      0.80926 *
+ * O              40     -0.10523      0.02895      0.36732 *
+ * O              41      0.02687     -0.10466      0.37168 *
+ * O              42      0.07885      0.07157      0.36777 *
+ * O              43     -1.65142      1.75208     -1.02511 *
+ * O              44     -0.67866     -2.26635     -1.02038 *
+ * O              45      2.32009      0.54255     -1.03354 *
+ * O              46      0.08567     -0.01931     -0.37815 *
+ * O              47     -0.02418      0.08385     -0.37607 *
+ * O              48     -0.06439     -0.07142     -0.37582 *
+ * O              49      1.65950     -1.78526      0.97844 *
+ * O              50      0.71527      2.33420      0.97835 *
+ * O              51     -2.35868     -0.55374      0.98680 *
+ * O              52     -0.18085     -0.00531     -0.76635 *
+ * O              53      0.08977     -0.14089     -0.75906 *
+ * O              54      0.07611      0.15385     -0.75937 *
+ * O              55      0.16552      0.02106      0.81218 *
+ * O              56     -0.09856      0.13065      0.81277 *
+ * O              57     -0.06654     -0.14702      0.81294 *
+ * O              58     -0.10475      0.02844      0.36868 *
+ * O              59      0.01967     -0.10042      0.36962 *
+ * O              60      0.07989      0.07861      0.37000 *
+ * O              61     -1.65968      1.75848     -1.03018 *
+ * O              62     -0.68769     -2.30129     -1.03344 *
+ * O              63      2.35685      0.55275     -1.03609 *
+ * O              64      0.08668     -0.02116     -0.37511 *
+ * O              65     -0.02570      0.08176     -0.37275 *
+ * O              66     -0.05911     -0.06669     -0.37544 *
+ * O              67      1.65481     -1.78908      0.96737 *
+ * O              68      0.71009      2.32141      0.98285 *
+ * O              69     -2.31933     -0.54483      0.96963 *
+ * O              70     -0.17787     -0.00847     -0.76529 *
+ * O              71      0.09221     -0.14549     -0.76050 *
+ * O              72      0.06899      0.15308     -0.75638 *
+ * O              73      0.16702      0.01837      0.81739 *
+ * O              74     -0.10637      0.12860      0.81480 *
+ * O              75     -0.06197     -0.14239      0.80796 *
+ * O              76     -0.10208      0.02283      0.37012 *
+ * O              77      0.02311     -0.09999      0.36896 *
+ * O              78      0.08211      0.07316      0.36810 *
+ * O              79     -1.66020      1.76919     -1.03916 *
+ * O              80     -0.67806     -2.27901     -1.02993 *
+ * O              81      2.33916      0.54795     -1.03526 *
+ * O              82      0.08936     -0.02147     -0.37745 *
+ * O              83     -0.02639      0.08276     -0.37780 *
+ * O              84     -0.06329     -0.06518     -0.36829 *
+ * O              85      1.65560     -1.78969      0.96722 *
+ * O              86      0.70254      2.30598      0.97685 *
+ * O              87     -2.34465     -0.54666      0.96698 *
+ * O              88     -0.17293     -0.00848     -0.76817 *
+ * O              89      0.09630     -0.14464     -0.75764 *
+ * O              90      0.07138      0.15107     -0.75894 *
+ * O              91      0.16735      0.01663      0.82123 *
+ * O              92     -0.10911      0.13678      0.81157 *
+ * O              93     -0.06170     -0.15214      0.81698 *
+ * O              94     -0.10212      0.02481      0.36797 *
+ * O              95      0.02111     -0.10135      0.36935 *
+ * O              96      0.07746      0.07536      0.36864 *
+ * O              97     -1.66988      1.78799     -1.03528 *
+ * O              98     -0.66620     -2.27077     -1.03039 *
+ * O              99      2.32370      0.54669     -1.03516 *
+ * O             100      0.08858     -0.01767     -0.37297 *
+ * O             101     -0.02631      0.08071     -0.38044 *
+ * O             102     -0.06074     -0.06512     -0.37196 *
+ * O             103      1.66071     -1.78210      0.97030 *
+ * O             104      0.70311      2.31046      0.97547 *
+ * O             105     -2.37508     -0.55130      0.98659 *
+ * O             106     -0.17525     -0.00607     -0.76032 *
+ * O             107      0.09430     -0.14549     -0.76220 *
+ * O             108      0.07652      0.15240     -0.76702 *
+ * O             109      0.16770      0.02197      0.81295 *
+ * O             110     -0.10397      0.12921      0.81519 *
+ * O             111     -0.06285     -0.15522      0.81006 *
+ * O             112     -0.10382      0.02365      0.37140 *
+ * O             113      0.02148     -0.10270      0.37550 *
+ * O             114      0.08026      0.07652      0.36248 *
+ * O             115     -1.65021      1.75632     -1.02690 *
+ * O             116     -0.70342     -2.31655     -1.03751 *
+ * O             117      2.33268      0.55807     -1.03652 *
+ * O             118      0.08556     -0.01931     -0.37638 *
+ * O             119     -0.02034      0.07755     -0.38030 *
+ * O             120     -0.06360     -0.06058     -0.37443 *
+ * O             121      1.66643     -1.80035      0.97018 *
+ * O             122      0.68999      2.29754      0.96803 *
+ * O             123     -2.34524     -0.53677      0.97302 *
+ * O             124     -0.17507     -0.01129     -0.75964 *
+ * O             125      0.09898     -0.14420     -0.75595 *
+ * O             126      0.07415      0.14959     -0.75966 *
+ * O             127      0.16525      0.02368      0.81186 *
+ * O             128     -0.10479      0.13126      0.80929 *
+ * O             129     -0.06465     -0.15763      0.81518 *
+ * O             130     -0.10227      0.02545      0.37047 *
+ * O             131      0.01998     -0.09627      0.37630 *
+ * O             132      0.08079      0.07477      0.36651 *
+ * O             133     -1.64940      1.74972     -1.02330 *
+ * O             134     -0.69023     -2.29459     -1.03307 *
+ * O             135      2.34930      0.55350     -1.02752 *
+ * O             136      0.08386     -0.01598     -0.37672 *
+ * O             137     -0.02294      0.08197     -0.37920 *
+ * O             138     -0.06341     -0.06418     -0.37632 *
+ * O             139      1.65271     -1.78630      0.96586 *
+ * O             140      0.70847      2.31134      0.97245 *
+ * O             141     -2.32936     -0.54124      0.97518 *
+ * O             142     -0.17634     -0.00981     -0.76434 *
+ * O             143      0.09137     -0.14797     -0.75737 *
+ * O             144      0.07406      0.15113     -0.75596 *
+ * O             145      0.16638      0.01935      0.82375 *
+ * O             146     -0.10430      0.12987      0.81009 *
+ * O             147     -0.06201     -0.15279      0.81788 *
+ * O             148     -0.10736      0.02817      0.36977 *
+ * O             149      0.01937     -0.10353      0.37244 *
+ * O             150      0.08096      0.07919      0.36409 *
+ * O             151     -1.67022      1.77885     -1.03871 *
+ * O             152     -0.69352     -2.30889     -1.03448 *
+ * O             153      2.34004      0.55637     -1.03928 *
+ * O             154      0.08674     -0.02108     -0.37915 *
+ * O             155     -0.02409      0.08379     -0.37762 *
+ * O             156     -0.06030     -0.06568     -0.37517 *
+ * O             157      1.63441     -1.76513      0.96626 *
+ * O             158      0.70166      2.29769      0.97129 *
+ * O             159     -2.33831     -0.54053      0.97307 *
+ * O             160     -0.17590     -0.01411     -0.76733 *
+ * O             161      0.09602     -0.14378     -0.75459 *
+ * O             162      0.07671      0.15656     -0.75454 *
+ * Al              1     -0.00078     -0.00043     -0.04369 *
+ * Al              2      0.00926     -0.00399     -0.87355 *
+ * Al              3     -0.00637     -0.00298     -1.98218 *
+ * Al              4     -0.00020     -0.00010     -0.25108 *
+ * Al              5     -0.00120     -0.00024     -0.08070 *
+ * Al              6      0.00003     -0.00014      0.08247 *
+ * Al              7      0.03002     -0.01215     -7.29639 *
+ * Al              8      0.00646     -0.00218      7.29946 *
+ * Al              9     -0.00076     -0.00054      0.05061 *
+ * Al             10     -0.00071      0.00022      0.27267 *
+ * Al             11     -0.00823      0.01285      0.87455 *
+ * Al             12     -0.00885      0.00687      1.99500 *
+ * Al             13     -0.00049      0.00005     -0.04377 *
+ * Al             14     -0.01552     -0.00249     -0.87068 *
+ * Al             15      0.00087     -0.01006     -1.97477 *
+ * Al             16     -0.00062      0.00001     -0.25146 *
+ * Al             17     -0.00111     -0.00029     -0.08042 *
+ * Al             18     -0.00080     -0.00017      0.08222 *
+ * Al             19     -0.00509     -0.03543     -7.29645 *
+ * Al             20      0.02396      0.02835      7.29835 *
+ * Al             21     -0.00072     -0.00021      0.04990 *
+ * Al             22     -0.00050     -0.00007      0.27267 *
+ * Al             23      0.02522      0.00225      0.87336 *
+ * Al             24     -0.00862      0.00815      1.98594 *
+ * Al             25     -0.00077     -0.00045     -0.04390 *
+ * Al             26     -0.00271      0.00076     -0.86818 *
+ * Al             27      0.00439     -0.00935     -1.99067 *
+ * Al             28     -0.00035      0.00006     -0.25129 *
+ * Al             29     -0.00115     -0.00040     -0.08057 *
+ * Al             30     -0.00018     -0.00020      0.08239 *
+ * Al             31     -0.02118     -0.01098     -7.29790 *
+ * Al             32     -0.00018      0.00968      7.29821 *
+ * Al             33     -0.00083     -0.00034      0.05065 *
+ * Al             34     -0.00053      0.00028      0.27314 *
+ * Al             35      0.01159     -0.00273      0.87343 *
+ * Al             36     -0.00366     -0.00221      1.97997 *
+ * Al             37     -0.00045      0.00035     -0.04412 *
+ * Al             38     -0.00904     -0.00690     -0.87351 *
+ * Al             39     -0.00145     -0.00690     -1.97769 *
+ * Al             40     -0.00085     -0.00016     -0.25208 *
+ * Al             41     -0.00129     -0.00044     -0.08077 *
+ * Al             42     -0.00045     -0.00034      0.08224 *
+ * Al             43      0.00410     -0.01786     -7.29639 *
+ * Al             44      0.02573      0.01542      7.29844 *
+ * Al             45     -0.00070     -0.00057      0.05013 *
+ * Al             46     -0.00036      0.00008      0.27287 *
+ * Al             47      0.00883      0.01632      0.87882 *
+ * Al             48     -0.01272     -0.00637      1.98656 *
+ * Al             49     -0.00038     -0.00033     -0.04452 *
+ * Al             50     -0.01665      0.00590     -0.86546 *
+ * Al             51      0.00572     -0.01113     -1.98258 *
+ * Al             52     -0.00081     -0.00003     -0.25146 *
+ * Al             53     -0.00062     -0.00018     -0.08061 *
+ * Al             54     -0.00040     -0.00020      0.08231 *
+ * Al             55      0.02393     -0.01478     -7.29675 *
+ * Al             56      0.03001      0.02566      7.29862 *
+ * Al             57     -0.00065     -0.00042      0.05014 *
+ * Al             58     -0.00048     -0.00006      0.27288 *
+ * Al             59     -0.00118      0.01578      0.87015 *
+ * Al             60     -0.01039      0.00217      1.98744 *
+ * Al             61     -0.00055     -0.00024     -0.04389 *
+ * Al             62     -0.03206      0.01001     -0.86646 *
+ * Al             63      0.01268     -0.01222     -1.98330 *
+ * Al             64      0.00010     -0.00003     -0.25147 *
+ * Al             65     -0.00104     -0.00031     -0.08071 *
+ * Al             66     -0.00010     -0.00023      0.08232 *
+ * Al             67      0.00360     -0.01448     -7.29741 *
+ * Al             68     -0.00408      0.03647      7.29786 *
+ * Al             69     -0.00072     -0.00039      0.05038 *
+ * Al             70     -0.00022     -0.00019      0.27280 *
+ * Al             71      0.01301     -0.00398      0.86429 *
+ * Al             72     -0.00020      0.00619      1.98180 *
+ * Al             73     -0.00149     -0.00029     -0.04385 *
+ * Al             74     -0.00710     -0.00615     -0.87802 *
+ * Al             75      0.00071      0.00306     -1.97929 *
+ * Al             76     -0.00102      0.00046     -0.25137 *
+ * Al             77     -0.00124     -0.00045     -0.08055 *
+ * Al             78     -0.00027      0.00033      0.08279 *
+ * Al             79      0.00570     -0.03329     -7.29560 *
+ * Al             80      0.01587      0.00295      7.29848 *
+ * Al             81     -0.00081     -0.00046      0.05017 *
+ * Al             82     -0.00094     -0.00022      0.27293 *
+ * Al             83      0.01047      0.00515      0.87591 *
+ * Al             84     -0.01200      0.00939      1.98706 *
+ * Al             85     -0.00056     -0.00027     -0.04383 *
+ * Al             86     -0.00974      0.01498     -0.87595 *
+ * Al             87     -0.00294     -0.00439     -1.98352 *
+ * Al             88     -0.00051     -0.00000     -0.25120 *
+ * Al             89     -0.00117     -0.00046     -0.08056 *
+ * Al             90     -0.00093     -0.00020      0.08261 *
+ * Al             91     -0.01021     -0.01956     -7.29632 *
+ * Al             92     -0.00386     -0.00232      7.29874 *
+ * Al             93     -0.00050     -0.00027      0.04968 *
+ * Al             94     -0.00055     -0.00008      0.27253 *
+ * Al             95      0.01620      0.00799      0.87912 *
+ * Al             96     -0.00911     -0.00067      1.98860 *
+ * Al             97     -0.00080     -0.00027     -0.04371 *
+ * Al             98     -0.02463      0.00092     -0.87414 *
+ * Al             99      0.00658     -0.00166     -1.97613 *
+ * Al            100     -0.00040     -0.00062     -0.25166 *
+ * Al            101     -0.00141     -0.00018     -0.08041 *
+ * Al            102     -0.00053     -0.00013      0.08256 *
+ * Al            103     -0.00222      0.00384     -7.29675 *
+ * Al            104     -0.01906      0.01852      7.29852 *
+ * Al            105     -0.00048     -0.00059      0.05006 *
+ * Al            106     -0.00045     -0.00066      0.27289 *
+ * Al            107      0.00856      0.01037      0.87084 *
+ * Al            108     -0.00299      0.00157      1.99364 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.95 s
+Calculation time    =    189.23 s
+Finalisation time   =      1.90 s
+Total time          =    194.08 s
+Peak Memory Use     = 1208208 kB
+  
+Overall parallel efficiency rating: Mediocre (52%)                              
+  
+Data was distributed by:-
+G-vector (128-way); efficiency rating: Mediocre (54%)                           
+k-point (2-way); efficiency rating: Excellent (96%)                             
+  
+Parallel notes:
+1) Calculation only took 192.5 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_6smp_202109031305_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_6smp_202109031305_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:01:15 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 256 processes.
+ Data is distributed by G-vector(128-way) and k-point(2-way)
+ G-vector communication optimised for up to 6-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          6
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      490.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               71.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          45.2 MB         0.0 MB |
+| Force calculation requirements                        1.7 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          606.8 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93903962E+004  0.00000000E+000                        13.34  <-- SCF
+      1  -7.24025078E+004  4.04952038E+000   4.81930060E+001      36.13  <-- SCF
+      2  -7.78252467E+004  1.95718735E+000   2.00842181E+001      52.48  <-- SCF
+      3  -7.79864690E+004  1.80210546E+000   5.97119548E-001      68.44  <-- SCF
+      4  -7.78412511E+004  1.95866797E+000  -5.37843840E-001      87.88  <-- SCF
+      5  -7.77211110E+004  1.34858550E+000  -4.44963492E-001     106.96  <-- SCF
+      6  -7.77152160E+004  1.12181373E+000  -2.18332198E-002     128.06  <-- SCF
+      7  -7.77129479E+004  1.05270612E+000  -8.40047628E-003     147.18  <-- SCF
+      8  -7.77104474E+004  1.02757566E+000  -9.26117241E-003     166.47  <-- SCF
+      9  -7.77084302E+004  9.96440502E-001  -7.47088452E-003     185.33  <-- SCF
+     10  -7.77059868E+004  1.11158438E+000  -9.04964606E-003     204.22  <-- SCF
+     11  -7.77052160E+004  1.16142631E+000  -2.85493552E-003     221.94  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21598074     eV
+Final free energy (E-TS)    =  -77705.21598075     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21598074     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16546      0.02416      0.81294 *
+ * O               2     -0.09616      0.12867      0.80709 *
+ * O               3     -0.06588     -0.14994      0.81406 *
+ * O               4     -0.10281      0.02695      0.37080 *
+ * O               5      0.02296     -0.10533      0.37258 *
+ * O               6      0.08183      0.07481      0.36653 *
+ * O               7     -1.64065      1.74452     -1.02151 *
+ * O               8     -0.69944     -2.30209     -1.02675 *
+ * O               9      2.35342      0.54882     -1.03858 *
+ * O              10      0.08666     -0.01690     -0.37847 *
+ * O              11     -0.02365      0.08637     -0.38175 *
+ * O              12     -0.06099     -0.06281     -0.37824 *
+ * O              13      1.64860     -1.77868      0.96839 *
+ * O              14      0.68951      2.28569      0.96500 *
+ * O              15     -2.33669     -0.53356      0.96999 *
+ * O              16     -0.17547     -0.00725     -0.76416 *
+ * O              17      0.09752     -0.14298     -0.75951 *
+ * O              18      0.07425      0.15725     -0.76225 *
+ * O              19      0.16803      0.01920      0.82015 *
+ * O              20     -0.10362      0.12991      0.81354 *
+ * O              21     -0.06580     -0.14472      0.81601 *
+ * O              22     -0.10143      0.02835      0.36943 *
+ * O              23      0.02263     -0.10179      0.36864 *
+ * O              24      0.07665      0.07523      0.36866 *
+ * O              25     -1.66701      1.77075     -1.03492 *
+ * O              26     -0.68684     -2.29542     -1.03275 *
+ * O              27      2.35749      0.55462     -1.04283 *
+ * O              28      0.08133     -0.01980     -0.37850 *
+ * O              29     -0.02038      0.07898     -0.37860 *
+ * O              30     -0.06232     -0.06315     -0.37473 *
+ * O              31      1.66467     -1.78624      0.98469 *
+ * O              32      0.69482      2.29819      0.97034 *
+ * O              33     -2.34814     -0.54040      0.97956 *
+ * O              34     -0.17813     -0.00834     -0.76088 *
+ * O              35      0.09778     -0.14689     -0.76193 *
+ * O              36      0.07469      0.14838     -0.75826 *
+ * O              37      0.16990      0.01744      0.81425 *
+ * O              38     -0.10322      0.13320      0.81620 *
+ * O              39     -0.06402     -0.14920      0.80926 *
+ * O              40     -0.10523      0.02895      0.36732 *
+ * O              41      0.02687     -0.10466      0.37168 *
+ * O              42      0.07885      0.07157      0.36777 *
+ * O              43     -1.65142      1.75208     -1.02511 *
+ * O              44     -0.67866     -2.26635     -1.02038 *
+ * O              45      2.32009      0.54255     -1.03354 *
+ * O              46      0.08567     -0.01931     -0.37815 *
+ * O              47     -0.02418      0.08385     -0.37607 *
+ * O              48     -0.06439     -0.07142     -0.37582 *
+ * O              49      1.65950     -1.78526      0.97844 *
+ * O              50      0.71527      2.33420      0.97835 *
+ * O              51     -2.35868     -0.55374      0.98680 *
+ * O              52     -0.18085     -0.00531     -0.76635 *
+ * O              53      0.08977     -0.14089     -0.75906 *
+ * O              54      0.07611      0.15385     -0.75937 *
+ * O              55      0.16552      0.02106      0.81218 *
+ * O              56     -0.09856      0.13065      0.81277 *
+ * O              57     -0.06654     -0.14702      0.81294 *
+ * O              58     -0.10475      0.02844      0.36868 *
+ * O              59      0.01967     -0.10042      0.36962 *
+ * O              60      0.07989      0.07861      0.37000 *
+ * O              61     -1.65968      1.75848     -1.03018 *
+ * O              62     -0.68769     -2.30129     -1.03344 *
+ * O              63      2.35685      0.55275     -1.03609 *
+ * O              64      0.08668     -0.02116     -0.37511 *
+ * O              65     -0.02570      0.08176     -0.37275 *
+ * O              66     -0.05911     -0.06669     -0.37544 *
+ * O              67      1.65481     -1.78908      0.96737 *
+ * O              68      0.71009      2.32141      0.98285 *
+ * O              69     -2.31933     -0.54483      0.96963 *
+ * O              70     -0.17787     -0.00847     -0.76529 *
+ * O              71      0.09221     -0.14549     -0.76050 *
+ * O              72      0.06899      0.15308     -0.75638 *
+ * O              73      0.16702      0.01837      0.81739 *
+ * O              74     -0.10637      0.12860      0.81480 *
+ * O              75     -0.06197     -0.14239      0.80796 *
+ * O              76     -0.10208      0.02283      0.37012 *
+ * O              77      0.02311     -0.09999      0.36896 *
+ * O              78      0.08211      0.07316      0.36810 *
+ * O              79     -1.66020      1.76919     -1.03916 *
+ * O              80     -0.67806     -2.27901     -1.02993 *
+ * O              81      2.33916      0.54795     -1.03526 *
+ * O              82      0.08936     -0.02147     -0.37745 *
+ * O              83     -0.02639      0.08276     -0.37780 *
+ * O              84     -0.06329     -0.06518     -0.36829 *
+ * O              85      1.65560     -1.78969      0.96722 *
+ * O              86      0.70254      2.30598      0.97685 *
+ * O              87     -2.34465     -0.54666      0.96698 *
+ * O              88     -0.17293     -0.00848     -0.76817 *
+ * O              89      0.09630     -0.14464     -0.75764 *
+ * O              90      0.07138      0.15107     -0.75894 *
+ * O              91      0.16735      0.01663      0.82123 *
+ * O              92     -0.10911      0.13678      0.81157 *
+ * O              93     -0.06170     -0.15214      0.81698 *
+ * O              94     -0.10212      0.02481      0.36797 *
+ * O              95      0.02111     -0.10135      0.36935 *
+ * O              96      0.07746      0.07536      0.36864 *
+ * O              97     -1.66988      1.78799     -1.03528 *
+ * O              98     -0.66620     -2.27077     -1.03039 *
+ * O              99      2.32370      0.54669     -1.03516 *
+ * O             100      0.08858     -0.01767     -0.37297 *
+ * O             101     -0.02631      0.08071     -0.38044 *
+ * O             102     -0.06074     -0.06512     -0.37196 *
+ * O             103      1.66071     -1.78210      0.97030 *
+ * O             104      0.70311      2.31046      0.97547 *
+ * O             105     -2.37508     -0.55130      0.98659 *
+ * O             106     -0.17525     -0.00607     -0.76032 *
+ * O             107      0.09430     -0.14549     -0.76220 *
+ * O             108      0.07652      0.15240     -0.76702 *
+ * O             109      0.16770      0.02197      0.81295 *
+ * O             110     -0.10397      0.12921      0.81519 *
+ * O             111     -0.06285     -0.15522      0.81006 *
+ * O             112     -0.10382      0.02365      0.37140 *
+ * O             113      0.02148     -0.10270      0.37550 *
+ * O             114      0.08026      0.07652      0.36248 *
+ * O             115     -1.65021      1.75632     -1.02690 *
+ * O             116     -0.70342     -2.31655     -1.03751 *
+ * O             117      2.33268      0.55807     -1.03652 *
+ * O             118      0.08556     -0.01931     -0.37638 *
+ * O             119     -0.02034      0.07755     -0.38030 *
+ * O             120     -0.06360     -0.06058     -0.37443 *
+ * O             121      1.66643     -1.80035      0.97018 *
+ * O             122      0.68999      2.29754      0.96803 *
+ * O             123     -2.34524     -0.53677      0.97302 *
+ * O             124     -0.17507     -0.01129     -0.75964 *
+ * O             125      0.09898     -0.14420     -0.75595 *
+ * O             126      0.07415      0.14959     -0.75966 *
+ * O             127      0.16525      0.02368      0.81186 *
+ * O             128     -0.10479      0.13126      0.80929 *
+ * O             129     -0.06465     -0.15763      0.81518 *
+ * O             130     -0.10227      0.02545      0.37047 *
+ * O             131      0.01998     -0.09627      0.37630 *
+ * O             132      0.08079      0.07477      0.36651 *
+ * O             133     -1.64940      1.74972     -1.02330 *
+ * O             134     -0.69023     -2.29459     -1.03307 *
+ * O             135      2.34930      0.55350     -1.02752 *
+ * O             136      0.08386     -0.01598     -0.37672 *
+ * O             137     -0.02294      0.08197     -0.37920 *
+ * O             138     -0.06341     -0.06418     -0.37632 *
+ * O             139      1.65271     -1.78630      0.96586 *
+ * O             140      0.70847      2.31134      0.97245 *
+ * O             141     -2.32936     -0.54124      0.97518 *
+ * O             142     -0.17634     -0.00981     -0.76434 *
+ * O             143      0.09137     -0.14797     -0.75737 *
+ * O             144      0.07406      0.15113     -0.75596 *
+ * O             145      0.16638      0.01935      0.82375 *
+ * O             146     -0.10430      0.12987      0.81009 *
+ * O             147     -0.06201     -0.15279      0.81788 *
+ * O             148     -0.10736      0.02817      0.36977 *
+ * O             149      0.01937     -0.10353      0.37244 *
+ * O             150      0.08096      0.07919      0.36409 *
+ * O             151     -1.67022      1.77885     -1.03871 *
+ * O             152     -0.69352     -2.30889     -1.03448 *
+ * O             153      2.34004      0.55637     -1.03928 *
+ * O             154      0.08674     -0.02108     -0.37915 *
+ * O             155     -0.02409      0.08379     -0.37762 *
+ * O             156     -0.06030     -0.06568     -0.37517 *
+ * O             157      1.63441     -1.76513      0.96626 *
+ * O             158      0.70166      2.29769      0.97129 *
+ * O             159     -2.33831     -0.54053      0.97307 *
+ * O             160     -0.17590     -0.01411     -0.76733 *
+ * O             161      0.09602     -0.14378     -0.75459 *
+ * O             162      0.07671      0.15656     -0.75454 *
+ * Al              1     -0.00078     -0.00043     -0.04369 *
+ * Al              2      0.00926     -0.00399     -0.87355 *
+ * Al              3     -0.00637     -0.00298     -1.98218 *
+ * Al              4     -0.00020     -0.00010     -0.25108 *
+ * Al              5     -0.00120     -0.00024     -0.08070 *
+ * Al              6      0.00003     -0.00014      0.08247 *
+ * Al              7      0.03002     -0.01215     -7.29639 *
+ * Al              8      0.00646     -0.00218      7.29946 *
+ * Al              9     -0.00076     -0.00054      0.05061 *
+ * Al             10     -0.00071      0.00022      0.27267 *
+ * Al             11     -0.00823      0.01285      0.87455 *
+ * Al             12     -0.00885      0.00687      1.99500 *
+ * Al             13     -0.00049      0.00005     -0.04377 *
+ * Al             14     -0.01552     -0.00249     -0.87068 *
+ * Al             15      0.00087     -0.01006     -1.97477 *
+ * Al             16     -0.00062      0.00001     -0.25146 *
+ * Al             17     -0.00111     -0.00029     -0.08042 *
+ * Al             18     -0.00080     -0.00017      0.08222 *
+ * Al             19     -0.00509     -0.03543     -7.29645 *
+ * Al             20      0.02396      0.02835      7.29835 *
+ * Al             21     -0.00072     -0.00021      0.04990 *
+ * Al             22     -0.00050     -0.00007      0.27267 *
+ * Al             23      0.02522      0.00225      0.87336 *
+ * Al             24     -0.00862      0.00815      1.98594 *
+ * Al             25     -0.00077     -0.00045     -0.04390 *
+ * Al             26     -0.00271      0.00076     -0.86818 *
+ * Al             27      0.00439     -0.00935     -1.99067 *
+ * Al             28     -0.00035      0.00006     -0.25129 *
+ * Al             29     -0.00115     -0.00040     -0.08057 *
+ * Al             30     -0.00018     -0.00020      0.08239 *
+ * Al             31     -0.02118     -0.01098     -7.29790 *
+ * Al             32     -0.00018      0.00968      7.29821 *
+ * Al             33     -0.00083     -0.00034      0.05065 *
+ * Al             34     -0.00053      0.00028      0.27314 *
+ * Al             35      0.01159     -0.00273      0.87343 *
+ * Al             36     -0.00366     -0.00221      1.97997 *
+ * Al             37     -0.00045      0.00035     -0.04412 *
+ * Al             38     -0.00904     -0.00690     -0.87351 *
+ * Al             39     -0.00145     -0.00690     -1.97769 *
+ * Al             40     -0.00085     -0.00016     -0.25208 *
+ * Al             41     -0.00129     -0.00044     -0.08077 *
+ * Al             42     -0.00045     -0.00034      0.08224 *
+ * Al             43      0.00410     -0.01786     -7.29639 *
+ * Al             44      0.02573      0.01542      7.29844 *
+ * Al             45     -0.00070     -0.00057      0.05013 *
+ * Al             46     -0.00036      0.00008      0.27287 *
+ * Al             47      0.00883      0.01632      0.87882 *
+ * Al             48     -0.01272     -0.00637      1.98656 *
+ * Al             49     -0.00038     -0.00033     -0.04452 *
+ * Al             50     -0.01665      0.00590     -0.86546 *
+ * Al             51      0.00572     -0.01113     -1.98258 *
+ * Al             52     -0.00081     -0.00003     -0.25146 *
+ * Al             53     -0.00062     -0.00018     -0.08061 *
+ * Al             54     -0.00040     -0.00020      0.08231 *
+ * Al             55      0.02393     -0.01478     -7.29675 *
+ * Al             56      0.03001      0.02566      7.29862 *
+ * Al             57     -0.00065     -0.00042      0.05014 *
+ * Al             58     -0.00048     -0.00006      0.27288 *
+ * Al             59     -0.00118      0.01578      0.87015 *
+ * Al             60     -0.01039      0.00217      1.98744 *
+ * Al             61     -0.00055     -0.00024     -0.04389 *
+ * Al             62     -0.03206      0.01001     -0.86646 *
+ * Al             63      0.01268     -0.01222     -1.98330 *
+ * Al             64      0.00010     -0.00003     -0.25147 *
+ * Al             65     -0.00104     -0.00031     -0.08071 *
+ * Al             66     -0.00010     -0.00023      0.08232 *
+ * Al             67      0.00360     -0.01448     -7.29741 *
+ * Al             68     -0.00408      0.03647      7.29786 *
+ * Al             69     -0.00072     -0.00039      0.05038 *
+ * Al             70     -0.00022     -0.00019      0.27280 *
+ * Al             71      0.01301     -0.00398      0.86429 *
+ * Al             72     -0.00020      0.00619      1.98180 *
+ * Al             73     -0.00149     -0.00029     -0.04385 *
+ * Al             74     -0.00710     -0.00615     -0.87802 *
+ * Al             75      0.00071      0.00306     -1.97929 *
+ * Al             76     -0.00102      0.00046     -0.25137 *
+ * Al             77     -0.00124     -0.00045     -0.08055 *
+ * Al             78     -0.00027      0.00033      0.08279 *
+ * Al             79      0.00570     -0.03329     -7.29560 *
+ * Al             80      0.01587      0.00295      7.29848 *
+ * Al             81     -0.00081     -0.00046      0.05017 *
+ * Al             82     -0.00094     -0.00022      0.27293 *
+ * Al             83      0.01047      0.00515      0.87591 *
+ * Al             84     -0.01200      0.00939      1.98706 *
+ * Al             85     -0.00056     -0.00027     -0.04383 *
+ * Al             86     -0.00974      0.01498     -0.87595 *
+ * Al             87     -0.00294     -0.00439     -1.98352 *
+ * Al             88     -0.00051     -0.00000     -0.25120 *
+ * Al             89     -0.00117     -0.00046     -0.08056 *
+ * Al             90     -0.00093     -0.00020      0.08261 *
+ * Al             91     -0.01021     -0.01956     -7.29632 *
+ * Al             92     -0.00386     -0.00232      7.29874 *
+ * Al             93     -0.00050     -0.00027      0.04968 *
+ * Al             94     -0.00055     -0.00008      0.27253 *
+ * Al             95      0.01620      0.00799      0.87912 *
+ * Al             96     -0.00911     -0.00067      1.98860 *
+ * Al             97     -0.00080     -0.00027     -0.04371 *
+ * Al             98     -0.02463      0.00092     -0.87414 *
+ * Al             99      0.00658     -0.00166     -1.97613 *
+ * Al            100     -0.00040     -0.00062     -0.25166 *
+ * Al            101     -0.00141     -0.00018     -0.08041 *
+ * Al            102     -0.00053     -0.00013      0.08256 *
+ * Al            103     -0.00222      0.00384     -7.29675 *
+ * Al            104     -0.01906      0.01852      7.29852 *
+ * Al            105     -0.00048     -0.00059      0.05006 *
+ * Al            106     -0.00045     -0.00066      0.27289 *
+ * Al            107      0.00856      0.01037      0.87084 *
+ * Al            108     -0.00299      0.00157      1.99364 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =     12.65 s
+Calculation time    =    222.61 s
+Finalisation time   =      2.18 s
+Total time          =    237.44 s
+Peak Memory Use     = 1196284 kB
+  
+Overall parallel efficiency rating: Poor (42%)                                  
+  
+Data was distributed by:-
+G-vector (128-way); efficiency rating: Poor (44%)                               
+k-point (2-way); efficiency rating: Excellent (96%)                             
+  
+Parallel notes:
+1) Calculation only took 235.5 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_8smp_202109031300_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_2nodes_256ranks_1threads_8smp_202109031300_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 12:56:22 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 256 processes.
+ Data is distributed by G-vector(128-way) and k-point(2-way)
+ G-vector communication optimised for up to 8-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          8
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      490.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               71.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          45.2 MB         0.0 MB |
+| Force calculation requirements                        1.7 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          606.8 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93903962E+004  0.00000000E+000                         9.13  <-- SCF
+      1  -7.24025078E+004  4.04952038E+000   4.81930060E+001      31.11  <-- SCF
+      2  -7.78252467E+004  1.95718735E+000   2.00842181E+001      46.56  <-- SCF
+      3  -7.79864690E+004  1.80210546E+000   5.97119548E-001      62.16  <-- SCF
+      4  -7.78412511E+004  1.95866797E+000  -5.37843840E-001      80.93  <-- SCF
+      5  -7.77211110E+004  1.34858550E+000  -4.44963492E-001      99.29  <-- SCF
+      6  -7.77152160E+004  1.12181373E+000  -2.18332198E-002     119.38  <-- SCF
+      7  -7.77129479E+004  1.05270612E+000  -8.40047628E-003     137.60  <-- SCF
+      8  -7.77104474E+004  1.02757566E+000  -9.26117241E-003     156.03  <-- SCF
+      9  -7.77084302E+004  9.96440502E-001  -7.47088452E-003     174.24  <-- SCF
+     10  -7.77059868E+004  1.11158438E+000  -9.04964606E-003     192.34  <-- SCF
+     11  -7.77052160E+004  1.16142631E+000  -2.85493552E-003     209.30  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21598074     eV
+Final free energy (E-TS)    =  -77705.21598075     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21598074     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16546      0.02416      0.81294 *
+ * O               2     -0.09616      0.12867      0.80709 *
+ * O               3     -0.06588     -0.14994      0.81406 *
+ * O               4     -0.10281      0.02695      0.37080 *
+ * O               5      0.02296     -0.10533      0.37258 *
+ * O               6      0.08183      0.07481      0.36653 *
+ * O               7     -1.64065      1.74452     -1.02151 *
+ * O               8     -0.69944     -2.30209     -1.02675 *
+ * O               9      2.35342      0.54882     -1.03858 *
+ * O              10      0.08666     -0.01690     -0.37847 *
+ * O              11     -0.02365      0.08637     -0.38175 *
+ * O              12     -0.06099     -0.06281     -0.37824 *
+ * O              13      1.64860     -1.77868      0.96839 *
+ * O              14      0.68951      2.28569      0.96500 *
+ * O              15     -2.33669     -0.53356      0.96999 *
+ * O              16     -0.17547     -0.00725     -0.76416 *
+ * O              17      0.09752     -0.14298     -0.75951 *
+ * O              18      0.07425      0.15725     -0.76225 *
+ * O              19      0.16803      0.01920      0.82015 *
+ * O              20     -0.10362      0.12991      0.81354 *
+ * O              21     -0.06580     -0.14472      0.81601 *
+ * O              22     -0.10143      0.02835      0.36943 *
+ * O              23      0.02263     -0.10179      0.36864 *
+ * O              24      0.07665      0.07523      0.36866 *
+ * O              25     -1.66701      1.77075     -1.03492 *
+ * O              26     -0.68684     -2.29542     -1.03275 *
+ * O              27      2.35749      0.55462     -1.04283 *
+ * O              28      0.08133     -0.01980     -0.37850 *
+ * O              29     -0.02038      0.07898     -0.37860 *
+ * O              30     -0.06232     -0.06315     -0.37473 *
+ * O              31      1.66467     -1.78624      0.98469 *
+ * O              32      0.69482      2.29819      0.97034 *
+ * O              33     -2.34814     -0.54040      0.97956 *
+ * O              34     -0.17813     -0.00834     -0.76088 *
+ * O              35      0.09778     -0.14689     -0.76193 *
+ * O              36      0.07469      0.14838     -0.75826 *
+ * O              37      0.16990      0.01744      0.81425 *
+ * O              38     -0.10322      0.13320      0.81620 *
+ * O              39     -0.06402     -0.14920      0.80926 *
+ * O              40     -0.10523      0.02895      0.36732 *
+ * O              41      0.02687     -0.10466      0.37168 *
+ * O              42      0.07885      0.07157      0.36777 *
+ * O              43     -1.65142      1.75208     -1.02511 *
+ * O              44     -0.67866     -2.26635     -1.02038 *
+ * O              45      2.32009      0.54255     -1.03354 *
+ * O              46      0.08567     -0.01931     -0.37815 *
+ * O              47     -0.02418      0.08385     -0.37607 *
+ * O              48     -0.06439     -0.07142     -0.37582 *
+ * O              49      1.65950     -1.78526      0.97844 *
+ * O              50      0.71527      2.33420      0.97835 *
+ * O              51     -2.35868     -0.55374      0.98680 *
+ * O              52     -0.18085     -0.00531     -0.76635 *
+ * O              53      0.08977     -0.14089     -0.75906 *
+ * O              54      0.07611      0.15385     -0.75937 *
+ * O              55      0.16552      0.02106      0.81218 *
+ * O              56     -0.09856      0.13065      0.81277 *
+ * O              57     -0.06654     -0.14702      0.81294 *
+ * O              58     -0.10475      0.02844      0.36868 *
+ * O              59      0.01967     -0.10042      0.36962 *
+ * O              60      0.07989      0.07861      0.37000 *
+ * O              61     -1.65968      1.75848     -1.03018 *
+ * O              62     -0.68769     -2.30129     -1.03344 *
+ * O              63      2.35685      0.55275     -1.03609 *
+ * O              64      0.08668     -0.02116     -0.37511 *
+ * O              65     -0.02570      0.08176     -0.37275 *
+ * O              66     -0.05911     -0.06669     -0.37544 *
+ * O              67      1.65481     -1.78908      0.96737 *
+ * O              68      0.71009      2.32141      0.98285 *
+ * O              69     -2.31933     -0.54483      0.96963 *
+ * O              70     -0.17787     -0.00847     -0.76529 *
+ * O              71      0.09221     -0.14549     -0.76050 *
+ * O              72      0.06899      0.15308     -0.75638 *
+ * O              73      0.16702      0.01837      0.81739 *
+ * O              74     -0.10637      0.12860      0.81480 *
+ * O              75     -0.06197     -0.14239      0.80796 *
+ * O              76     -0.10208      0.02283      0.37012 *
+ * O              77      0.02311     -0.09999      0.36896 *
+ * O              78      0.08211      0.07316      0.36810 *
+ * O              79     -1.66020      1.76919     -1.03916 *
+ * O              80     -0.67806     -2.27901     -1.02993 *
+ * O              81      2.33916      0.54795     -1.03526 *
+ * O              82      0.08936     -0.02147     -0.37745 *
+ * O              83     -0.02639      0.08276     -0.37780 *
+ * O              84     -0.06329     -0.06518     -0.36829 *
+ * O              85      1.65560     -1.78969      0.96722 *
+ * O              86      0.70254      2.30598      0.97685 *
+ * O              87     -2.34465     -0.54666      0.96698 *
+ * O              88     -0.17293     -0.00848     -0.76817 *
+ * O              89      0.09630     -0.14464     -0.75764 *
+ * O              90      0.07138      0.15107     -0.75894 *
+ * O              91      0.16735      0.01663      0.82123 *
+ * O              92     -0.10911      0.13678      0.81157 *
+ * O              93     -0.06170     -0.15214      0.81698 *
+ * O              94     -0.10212      0.02481      0.36797 *
+ * O              95      0.02111     -0.10135      0.36935 *
+ * O              96      0.07746      0.07536      0.36864 *
+ * O              97     -1.66988      1.78799     -1.03528 *
+ * O              98     -0.66620     -2.27077     -1.03039 *
+ * O              99      2.32370      0.54669     -1.03516 *
+ * O             100      0.08858     -0.01767     -0.37297 *
+ * O             101     -0.02631      0.08071     -0.38044 *
+ * O             102     -0.06074     -0.06512     -0.37196 *
+ * O             103      1.66071     -1.78210      0.97030 *
+ * O             104      0.70311      2.31046      0.97547 *
+ * O             105     -2.37508     -0.55130      0.98659 *
+ * O             106     -0.17525     -0.00607     -0.76032 *
+ * O             107      0.09430     -0.14549     -0.76220 *
+ * O             108      0.07652      0.15240     -0.76702 *
+ * O             109      0.16770      0.02197      0.81295 *
+ * O             110     -0.10397      0.12921      0.81519 *
+ * O             111     -0.06285     -0.15522      0.81006 *
+ * O             112     -0.10382      0.02365      0.37140 *
+ * O             113      0.02148     -0.10270      0.37550 *
+ * O             114      0.08026      0.07652      0.36248 *
+ * O             115     -1.65021      1.75632     -1.02690 *
+ * O             116     -0.70342     -2.31655     -1.03751 *
+ * O             117      2.33268      0.55807     -1.03652 *
+ * O             118      0.08556     -0.01931     -0.37638 *
+ * O             119     -0.02034      0.07755     -0.38030 *
+ * O             120     -0.06360     -0.06058     -0.37443 *
+ * O             121      1.66643     -1.80035      0.97018 *
+ * O             122      0.68999      2.29754      0.96803 *
+ * O             123     -2.34524     -0.53677      0.97302 *
+ * O             124     -0.17507     -0.01129     -0.75964 *
+ * O             125      0.09898     -0.14420     -0.75595 *
+ * O             126      0.07415      0.14959     -0.75966 *
+ * O             127      0.16525      0.02368      0.81186 *
+ * O             128     -0.10479      0.13126      0.80929 *
+ * O             129     -0.06465     -0.15763      0.81518 *
+ * O             130     -0.10227      0.02545      0.37047 *
+ * O             131      0.01998     -0.09627      0.37630 *
+ * O             132      0.08079      0.07477      0.36651 *
+ * O             133     -1.64940      1.74972     -1.02330 *
+ * O             134     -0.69023     -2.29459     -1.03307 *
+ * O             135      2.34930      0.55350     -1.02752 *
+ * O             136      0.08386     -0.01598     -0.37672 *
+ * O             137     -0.02294      0.08197     -0.37920 *
+ * O             138     -0.06341     -0.06418     -0.37632 *
+ * O             139      1.65271     -1.78630      0.96586 *
+ * O             140      0.70847      2.31134      0.97245 *
+ * O             141     -2.32936     -0.54124      0.97518 *
+ * O             142     -0.17634     -0.00981     -0.76434 *
+ * O             143      0.09137     -0.14797     -0.75737 *
+ * O             144      0.07406      0.15113     -0.75596 *
+ * O             145      0.16638      0.01935      0.82375 *
+ * O             146     -0.10430      0.12987      0.81009 *
+ * O             147     -0.06201     -0.15279      0.81788 *
+ * O             148     -0.10736      0.02817      0.36977 *
+ * O             149      0.01937     -0.10353      0.37244 *
+ * O             150      0.08096      0.07919      0.36409 *
+ * O             151     -1.67022      1.77885     -1.03871 *
+ * O             152     -0.69352     -2.30889     -1.03448 *
+ * O             153      2.34004      0.55637     -1.03928 *
+ * O             154      0.08674     -0.02108     -0.37915 *
+ * O             155     -0.02409      0.08379     -0.37762 *
+ * O             156     -0.06030     -0.06568     -0.37517 *
+ * O             157      1.63441     -1.76513      0.96626 *
+ * O             158      0.70166      2.29769      0.97129 *
+ * O             159     -2.33831     -0.54053      0.97307 *
+ * O             160     -0.17590     -0.01411     -0.76733 *
+ * O             161      0.09602     -0.14378     -0.75459 *
+ * O             162      0.07671      0.15656     -0.75454 *
+ * Al              1     -0.00078     -0.00043     -0.04369 *
+ * Al              2      0.00926     -0.00399     -0.87355 *
+ * Al              3     -0.00637     -0.00298     -1.98218 *
+ * Al              4     -0.00020     -0.00010     -0.25108 *
+ * Al              5     -0.00120     -0.00024     -0.08070 *
+ * Al              6      0.00003     -0.00014      0.08247 *
+ * Al              7      0.03002     -0.01215     -7.29639 *
+ * Al              8      0.00646     -0.00218      7.29946 *
+ * Al              9     -0.00076     -0.00054      0.05061 *
+ * Al             10     -0.00071      0.00022      0.27267 *
+ * Al             11     -0.00823      0.01285      0.87455 *
+ * Al             12     -0.00885      0.00687      1.99500 *
+ * Al             13     -0.00049      0.00005     -0.04377 *
+ * Al             14     -0.01552     -0.00249     -0.87068 *
+ * Al             15      0.00087     -0.01006     -1.97477 *
+ * Al             16     -0.00062      0.00001     -0.25146 *
+ * Al             17     -0.00111     -0.00029     -0.08042 *
+ * Al             18     -0.00080     -0.00017      0.08222 *
+ * Al             19     -0.00509     -0.03543     -7.29645 *
+ * Al             20      0.02396      0.02835      7.29835 *
+ * Al             21     -0.00072     -0.00021      0.04990 *
+ * Al             22     -0.00050     -0.00007      0.27267 *
+ * Al             23      0.02522      0.00225      0.87336 *
+ * Al             24     -0.00862      0.00815      1.98594 *
+ * Al             25     -0.00077     -0.00045     -0.04390 *
+ * Al             26     -0.00271      0.00076     -0.86818 *
+ * Al             27      0.00439     -0.00935     -1.99067 *
+ * Al             28     -0.00035      0.00006     -0.25129 *
+ * Al             29     -0.00115     -0.00040     -0.08057 *
+ * Al             30     -0.00018     -0.00020      0.08239 *
+ * Al             31     -0.02118     -0.01098     -7.29790 *
+ * Al             32     -0.00018      0.00968      7.29821 *
+ * Al             33     -0.00083     -0.00034      0.05065 *
+ * Al             34     -0.00053      0.00028      0.27314 *
+ * Al             35      0.01159     -0.00273      0.87343 *
+ * Al             36     -0.00366     -0.00221      1.97997 *
+ * Al             37     -0.00045      0.00035     -0.04412 *
+ * Al             38     -0.00904     -0.00690     -0.87351 *
+ * Al             39     -0.00145     -0.00690     -1.97769 *
+ * Al             40     -0.00085     -0.00016     -0.25208 *
+ * Al             41     -0.00129     -0.00044     -0.08077 *
+ * Al             42     -0.00045     -0.00034      0.08224 *
+ * Al             43      0.00410     -0.01786     -7.29639 *
+ * Al             44      0.02573      0.01542      7.29844 *
+ * Al             45     -0.00070     -0.00057      0.05013 *
+ * Al             46     -0.00036      0.00008      0.27287 *
+ * Al             47      0.00883      0.01632      0.87882 *
+ * Al             48     -0.01272     -0.00637      1.98656 *
+ * Al             49     -0.00038     -0.00033     -0.04452 *
+ * Al             50     -0.01665      0.00590     -0.86546 *
+ * Al             51      0.00572     -0.01113     -1.98258 *
+ * Al             52     -0.00081     -0.00003     -0.25146 *
+ * Al             53     -0.00062     -0.00018     -0.08061 *
+ * Al             54     -0.00040     -0.00020      0.08231 *
+ * Al             55      0.02393     -0.01478     -7.29675 *
+ * Al             56      0.03001      0.02566      7.29862 *
+ * Al             57     -0.00065     -0.00042      0.05014 *
+ * Al             58     -0.00048     -0.00006      0.27288 *
+ * Al             59     -0.00118      0.01578      0.87015 *
+ * Al             60     -0.01039      0.00217      1.98744 *
+ * Al             61     -0.00055     -0.00024     -0.04389 *
+ * Al             62     -0.03206      0.01001     -0.86646 *
+ * Al             63      0.01268     -0.01222     -1.98330 *
+ * Al             64      0.00010     -0.00003     -0.25147 *
+ * Al             65     -0.00104     -0.00031     -0.08071 *
+ * Al             66     -0.00010     -0.00023      0.08232 *
+ * Al             67      0.00360     -0.01448     -7.29741 *
+ * Al             68     -0.00408      0.03647      7.29786 *
+ * Al             69     -0.00072     -0.00039      0.05038 *
+ * Al             70     -0.00022     -0.00019      0.27280 *
+ * Al             71      0.01301     -0.00398      0.86429 *
+ * Al             72     -0.00020      0.00619      1.98180 *
+ * Al             73     -0.00149     -0.00029     -0.04385 *
+ * Al             74     -0.00710     -0.00615     -0.87802 *
+ * Al             75      0.00071      0.00306     -1.97929 *
+ * Al             76     -0.00102      0.00046     -0.25137 *
+ * Al             77     -0.00124     -0.00045     -0.08055 *
+ * Al             78     -0.00027      0.00033      0.08279 *
+ * Al             79      0.00570     -0.03329     -7.29560 *
+ * Al             80      0.01587      0.00295      7.29848 *
+ * Al             81     -0.00081     -0.00046      0.05017 *
+ * Al             82     -0.00094     -0.00022      0.27293 *
+ * Al             83      0.01047      0.00515      0.87591 *
+ * Al             84     -0.01200      0.00939      1.98706 *
+ * Al             85     -0.00056     -0.00027     -0.04383 *
+ * Al             86     -0.00974      0.01498     -0.87595 *
+ * Al             87     -0.00294     -0.00439     -1.98352 *
+ * Al             88     -0.00051     -0.00000     -0.25120 *
+ * Al             89     -0.00117     -0.00046     -0.08056 *
+ * Al             90     -0.00093     -0.00020      0.08261 *
+ * Al             91     -0.01021     -0.01956     -7.29632 *
+ * Al             92     -0.00386     -0.00232      7.29874 *
+ * Al             93     -0.00050     -0.00027      0.04968 *
+ * Al             94     -0.00055     -0.00008      0.27253 *
+ * Al             95      0.01620      0.00799      0.87912 *
+ * Al             96     -0.00911     -0.00067      1.98860 *
+ * Al             97     -0.00080     -0.00027     -0.04371 *
+ * Al             98     -0.02463      0.00092     -0.87414 *
+ * Al             99      0.00658     -0.00166     -1.97613 *
+ * Al            100     -0.00040     -0.00062     -0.25166 *
+ * Al            101     -0.00141     -0.00018     -0.08041 *
+ * Al            102     -0.00053     -0.00013      0.08256 *
+ * Al            103     -0.00222      0.00384     -7.29675 *
+ * Al            104     -0.01906      0.01852      7.29852 *
+ * Al            105     -0.00048     -0.00059      0.05006 *
+ * Al            106     -0.00045     -0.00066      0.27289 *
+ * Al            107      0.00856      0.01037      0.87084 *
+ * Al            108     -0.00299      0.00157      1.99364 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      8.30 s
+Calculation time    =    213.00 s
+Finalisation time   =      2.57 s
+Total time          =    223.87 s
+Peak Memory Use     = 1201144 kB
+  
+Overall parallel efficiency rating: Poor (45%)                                  
+  
+Data was distributed by:-
+G-vector (128-way); efficiency rating: Poor (46%)                               
+k-point (2-way); efficiency rating: Excellent (94%)                             
+  
+Parallel notes:
+1) Calculation only took 221.6 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_4nodes_512ranks_1threads_202109031311_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_4nodes_512ranks_1threads_202109031311_mkl.castep
@@ -1,0 +1,871 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:07:28 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 512 processes.
+ Data is distributed by G-vector(256-way) and k-point(2-way)
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      501.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               49.7 MB         0.0 MB |
+| Electronic energy minimisation requirements          27.5 MB         0.0 MB |
+| Force calculation requirements                        0.9 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          578.1 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94040471E+004  0.00000000E+000                        15.98  <-- SCF
+      1  -7.23974364E+004  3.96519365E+000   4.81236640E+001      38.00  <-- SCF
+      2  -7.78239890E+004  1.90527988E+000   2.00983428E+001      52.65  <-- SCF
+      3  -7.79864514E+004  1.80112768E+000   6.01712758E-001      67.51  <-- SCF
+      4  -7.78412701E+004  1.95926701E+000  -5.37708637E-001      86.73  <-- SCF
+      5  -7.77211118E+004  1.34874508E+000  -4.45030685E-001     106.12  <-- SCF
+      6  -7.77152137E+004  1.12183213E+000  -2.18446268E-002     126.95  <-- SCF
+      7  -7.77129476E+004  1.05274255E+000  -8.39298534E-003     146.33  <-- SCF
+      8  -7.77104480E+004  1.02760092E+000  -9.25783876E-003     164.81  <-- SCF
+      9  -7.77084300E+004  9.96413396E-001  -7.47409974E-003     183.88  <-- SCF
+     10  -7.77059702E+004  1.11136371E+000  -9.11059711E-003     203.72  <-- SCF
+     11  -7.77052109E+004  1.16270888E+000  -2.81206666E-003     223.10  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21089850     eV
+Final free energy (E-TS)    =  -77705.21089850     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21089850     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16835      0.02132      0.83077 *
+ * O               2     -0.10063      0.12589      0.83039 *
+ * O               3     -0.06668     -0.15169      0.83441 *
+ * O               4     -0.10532      0.02250      0.37911 *
+ * O               5      0.02443     -0.09659      0.38396 *
+ * O               6      0.07699      0.07308      0.38215 *
+ * O               7     -1.64777      1.74586     -1.01914 *
+ * O               8     -0.68785     -2.29731     -1.02803 *
+ * O               9      2.35044      0.55287     -1.02276 *
+ * O              10      0.08193     -0.01831     -0.39138 *
+ * O              11     -0.02032      0.07676     -0.39128 *
+ * O              12     -0.05695     -0.06644     -0.38820 *
+ * O              13      1.66913     -1.78910      0.95583 *
+ * O              14      0.69898      2.30235      0.96805 *
+ * O              15     -2.35436     -0.54291      0.96720 *
+ * O              16     -0.17019     -0.01542     -0.78243 *
+ * O              17      0.08926     -0.13996     -0.77672 *
+ * O              18      0.07517      0.15829     -0.78480 *
+ * O              19      0.16790      0.02320      0.83960 *
+ * O              20     -0.09889      0.12718      0.83058 *
+ * O              21     -0.05971     -0.14970      0.83328 *
+ * O              22     -0.10370      0.02091      0.38699 *
+ * O              23      0.02643     -0.10073      0.38394 *
+ * O              24      0.07943      0.07042      0.38288 *
+ * O              25     -1.66396      1.77316     -1.01389 *
+ * O              26     -0.68290     -2.29835     -1.02792 *
+ * O              27      2.33970      0.55457     -1.02739 *
+ * O              28      0.08765     -0.01742     -0.38951 *
+ * O              29     -0.02032      0.08024     -0.38994 *
+ * O              30     -0.05797     -0.06299     -0.38791 *
+ * O              31      1.66359     -1.77415      0.96803 *
+ * O              32      0.71062      2.31552      0.96206 *
+ * O              33     -2.38397     -0.55468      0.96195 *
+ * O              34     -0.17672     -0.01832     -0.78697 *
+ * O              35      0.09637     -0.13581     -0.77995 *
+ * O              36      0.07611      0.14664     -0.78445 *
+ * O              37      0.16940      0.01971      0.83519 *
+ * O              38     -0.10504      0.12263      0.83225 *
+ * O              39     -0.05675     -0.15017      0.82985 *
+ * O              40     -0.09756      0.02273      0.38113 *
+ * O              41      0.02957     -0.10024      0.38757 *
+ * O              42      0.07806      0.07544      0.37769 *
+ * O              43     -1.66498      1.77533     -1.01409 *
+ * O              44     -0.68398     -2.29918     -1.02501 *
+ * O              45      2.32885      0.55405     -1.03589 *
+ * O              46      0.08652     -0.01875     -0.39072 *
+ * O              47     -0.02370      0.08221     -0.39008 *
+ * O              48     -0.05562     -0.06487     -0.38865 *
+ * O              49      1.65501     -1.76931      0.96848 *
+ * O              50      0.72159      2.34028      0.96965 *
+ * O              51     -2.38155     -0.55061      0.96161 *
+ * O              52     -0.17400     -0.01233     -0.78629 *
+ * O              53      0.09416     -0.13809     -0.78180 *
+ * O              54      0.07579      0.15374     -0.78137 *
+ * O              55      0.16488      0.02278      0.84126 *
+ * O              56     -0.09807      0.12879      0.83211 *
+ * O              57     -0.05824     -0.15266      0.83351 *
+ * O              58     -0.10185      0.02429      0.38313 *
+ * O              59      0.02319     -0.09934      0.38443 *
+ * O              60      0.07744      0.07775      0.38201 *
+ * O              61     -1.65722      1.76756     -1.02169 *
+ * O              62     -0.69609     -2.31843     -1.02161 *
+ * O              63      2.34362      0.55496     -1.02785 *
+ * O              64      0.08686     -0.01602     -0.39227 *
+ * O              65     -0.02498      0.07757     -0.39069 *
+ * O              66     -0.05945     -0.06479     -0.38650 *
+ * O              67      1.66367     -1.78522      0.96059 *
+ * O              68      0.70247      2.31013      0.97068 *
+ * O              69     -2.32767     -0.54709      0.97360 *
+ * O              70     -0.16848     -0.01246     -0.78307 *
+ * O              71      0.09971     -0.14286     -0.77763 *
+ * O              72      0.07416      0.14821     -0.77862 *
+ * O              73      0.16629      0.02195      0.83642 *
+ * O              74     -0.09947      0.12853      0.82966 *
+ * O              75     -0.05696     -0.15377      0.84076 *
+ * O              76     -0.09820      0.01855      0.38491 *
+ * O              77      0.02364     -0.09944      0.38671 *
+ * O              78      0.07798      0.07640      0.38375 *
+ * O              79     -1.65607      1.75763     -1.02566 *
+ * O              80     -0.68235     -2.29744     -1.02768 *
+ * O              81      2.35297      0.54866     -1.02442 *
+ * O              82      0.08721     -0.01883     -0.38493 *
+ * O              83     -0.01907      0.08136     -0.39269 *
+ * O              84     -0.05805     -0.06566     -0.38414 *
+ * O              85      1.63966     -1.75185      0.96439 *
+ * O              86      0.69725      2.29010      0.97060 *
+ * O              87     -2.37424     -0.54773      0.96405 *
+ * O              88     -0.17561     -0.01085     -0.78613 *
+ * O              89      0.09924     -0.14067     -0.78003 *
+ * O              90      0.07719      0.14924     -0.77732 *
+ * O              91      0.16476      0.02182      0.83800 *
+ * O              92     -0.10069      0.13238      0.83125 *
+ * O              93     -0.06015     -0.15272      0.83324 *
+ * O              94     -0.10095      0.02430      0.38679 *
+ * O              95      0.02661     -0.10031      0.38772 *
+ * O              96      0.07881      0.07316      0.38179 *
+ * O              97     -1.66769      1.77960     -1.02199 *
+ * O              98     -0.68528     -2.28838     -1.02459 *
+ * O              99      2.33291      0.54713     -1.02456 *
+ * O             100      0.08226     -0.01831     -0.39094 *
+ * O             101     -0.01936      0.08062     -0.38609 *
+ * O             102     -0.05820     -0.06428     -0.38701 *
+ * O             103      1.66222     -1.77540      0.96216 *
+ * O             104      0.70039      2.31059      0.96620 *
+ * O             105     -2.37497     -0.54632      0.96661 *
+ * O             106     -0.17533     -0.01311     -0.77903 *
+ * O             107      0.09357     -0.14284     -0.78077 *
+ * O             108      0.07551      0.15057     -0.78639 *
+ * O             109      0.16745      0.01986      0.83588 *
+ * O             110     -0.10046      0.12467      0.83717 *
+ * O             111     -0.05630     -0.15838      0.82886 *
+ * O             112     -0.09887      0.02286      0.37771 *
+ * O             113      0.02494     -0.09828      0.38423 *
+ * O             114      0.07528      0.07408      0.38262 *
+ * O             115     -1.65556      1.75693     -1.02997 *
+ * O             116     -0.69475     -2.30806     -1.02587 *
+ * O             117      2.33792      0.55057     -1.02723 *
+ * O             118      0.08765     -0.01847     -0.38875 *
+ * O             119     -0.02165      0.07990     -0.39214 *
+ * O             120     -0.05943     -0.06601     -0.38907 *
+ * O             121      1.65297     -1.76768      0.96352 *
+ * O             122      0.72157      2.33033      0.95716 *
+ * O             123     -2.34531     -0.54984      0.96773 *
+ * O             124     -0.17228     -0.01129     -0.78050 *
+ * O             125      0.09676     -0.14490     -0.78057 *
+ * O             126      0.07089      0.15337     -0.78177 *
+ * O             127      0.16115      0.02227      0.84185 *
+ * O             128     -0.10303      0.12375      0.83517 *
+ * O             129     -0.05810     -0.15100      0.83411 *
+ * O             130     -0.10364      0.01752      0.38543 *
+ * O             131      0.02277     -0.10447      0.38642 *
+ * O             132      0.07756      0.07049      0.38120 *
+ * O             133     -1.66560      1.77344     -1.01461 *
+ * O             134     -0.69255     -2.32101     -1.02912 *
+ * O             135      2.33280      0.55818     -1.03222 *
+ * O             136      0.08688     -0.01755     -0.39492 *
+ * O             137     -0.02433      0.08009     -0.38899 *
+ * O             138     -0.05851     -0.06502     -0.38376 *
+ * O             139      1.62402     -1.72508      0.95117 *
+ * O             140      0.71286      2.30713      0.95289 *
+ * O             141     -2.38159     -0.55339      0.96411 *
+ * O             142     -0.17286     -0.00948     -0.78728 *
+ * O             143      0.09383     -0.14417     -0.77833 *
+ * O             144      0.07752      0.15183     -0.78278 *
+ * O             145      0.16617      0.01873      0.83873 *
+ * O             146     -0.10322      0.12873      0.83002 *
+ * O             147     -0.05859     -0.15523      0.83770 *
+ * O             148     -0.10135      0.02072      0.38320 *
+ * O             149      0.01960     -0.09942      0.38902 *
+ * O             150      0.07958      0.07330      0.38554 *
+ * O             151     -1.66310      1.76724     -1.00903 *
+ * O             152     -0.67966     -2.28667     -1.02453 *
+ * O             153      2.34833      0.55169     -1.03607 *
+ * O             154      0.08071     -0.01561     -0.39013 *
+ * O             155     -0.02507      0.07975     -0.39310 *
+ * O             156     -0.06092     -0.06568     -0.38658 *
+ * O             157      1.63361     -1.74447      0.95822 *
+ * O             158      0.71478      2.32117      0.96174 *
+ * O             159     -2.38067     -0.54377      0.95644 *
+ * O             160     -0.17900     -0.01507     -0.77755 *
+ * O             161      0.09116     -0.13759     -0.78148 *
+ * O             162      0.07860      0.14787     -0.78267 *
+ * Al              1      0.00113     -0.00116     -0.02327 *
+ * Al              2      0.00082      0.00376     -0.86201 *
+ * Al              3     -0.00027     -0.00565     -1.97540 *
+ * Al              4      0.00085     -0.00077     -0.23276 *
+ * Al              5      0.00010     -0.00116     -0.08241 *
+ * Al              6      0.00120     -0.00106      0.08493 *
+ * Al              7      0.02666     -0.01106     -7.29085 *
+ * Al              8      0.00768      0.00262      7.29526 *
+ * Al              9      0.00132     -0.00117      0.02950 *
+ * Al             10      0.00071     -0.00090      0.25444 *
+ * Al             11     -0.01985      0.00162      0.86616 *
+ * Al             12     -0.00485      0.00462      1.97860 *
+ * Al             13      0.00064     -0.00112     -0.02356 *
+ * Al             14     -0.00506     -0.00691     -0.85683 *
+ * Al             15      0.00571     -0.00717     -1.97135 *
+ * Al             16      0.00090     -0.00074     -0.23312 *
+ * Al             17      0.00081     -0.00115     -0.08228 *
+ * Al             18      0.00075     -0.00072      0.08473 *
+ * Al             19     -0.01501     -0.00275     -7.29191 *
+ * Al             20      0.00207      0.01844      7.29487 *
+ * Al             21      0.00116     -0.00085      0.02983 *
+ * Al             22      0.00146     -0.00142      0.25422 *
+ * Al             23      0.00222     -0.01612      0.86314 *
+ * Al             24      0.00589      0.00442      1.97529 *
+ * Al             25      0.00096     -0.00117     -0.02313 *
+ * Al             26     -0.01771     -0.00112     -0.86572 *
+ * Al             27      0.00962     -0.00524     -1.97527 *
+ * Al             28      0.00091     -0.00048     -0.23298 *
+ * Al             29      0.00049     -0.00102     -0.08246 *
+ * Al             30      0.00142     -0.00096      0.08487 *
+ * Al             31     -0.01157      0.00366     -7.29179 *
+ * Al             32      0.01219      0.01420      7.29319 *
+ * Al             33      0.00125     -0.00087      0.02959 *
+ * Al             34      0.00107     -0.00080      0.25434 *
+ * Al             35     -0.01761     -0.01949      0.87206 *
+ * Al             36      0.00546     -0.00570      1.97151 *
+ * Al             37      0.00090     -0.00097     -0.02306 *
+ * Al             38     -0.00962     -0.00689     -0.86648 *
+ * Al             39      0.00530     -0.00109     -1.97025 *
+ * Al             40      0.00115     -0.00074     -0.23308 *
+ * Al             41      0.00084     -0.00104     -0.08221 *
+ * Al             42      0.00150     -0.00076      0.08487 *
+ * Al             43      0.00360     -0.01428     -7.29226 *
+ * Al             44      0.01179      0.01201      7.29425 *
+ * Al             45      0.00087     -0.00145      0.02973 *
+ * Al             46      0.00105     -0.00116      0.25410 *
+ * Al             47      0.00335      0.00585      0.87102 *
+ * Al             48     -0.00691     -0.00019      1.98260 *
+ * Al             49      0.00147     -0.00131     -0.02336 *
+ * Al             50     -0.00729      0.00195     -0.86273 *
+ * Al             51      0.00137     -0.00843     -1.97298 *
+ * Al             52      0.00121     -0.00075     -0.23266 *
+ * Al             53      0.00048     -0.00125     -0.08234 *
+ * Al             54      0.00105     -0.00075      0.08455 *
+ * Al             55     -0.01819      0.01410     -7.29123 *
+ * Al             56      0.01117      0.01121      7.29484 *
+ * Al             57      0.00072     -0.00124      0.02979 *
+ * Al             58      0.00120     -0.00128      0.25428 *
+ * Al             59      0.01109     -0.00610      0.85700 *
+ * Al             60      0.00802      0.00658      1.98497 *
+ * Al             61      0.00098     -0.00108     -0.02351 *
+ * Al             62     -0.01444     -0.00315     -0.85881 *
+ * Al             63      0.01034     -0.00707     -1.97405 *
+ * Al             64      0.00115     -0.00120     -0.23350 *
+ * Al             65      0.00092     -0.00098     -0.08207 *
+ * Al             66      0.00149     -0.00096      0.08491 *
+ * Al             67     -0.02505     -0.00703     -7.29133 *
+ * Al             68     -0.01102      0.01891      7.29378 *
+ * Al             69      0.00111     -0.00141      0.02981 *
+ * Al             70      0.00126     -0.00106      0.25374 *
+ * Al             71      0.01164     -0.01510      0.86577 *
+ * Al             72      0.00326      0.00486      1.97621 *
+ * Al             73      0.00092     -0.00103     -0.02349 *
+ * Al             74     -0.00178     -0.01070     -0.86212 *
+ * Al             75      0.00334     -0.00319     -1.97216 *
+ * Al             76      0.00051     -0.00085     -0.23300 *
+ * Al             77      0.00049     -0.00098     -0.08267 *
+ * Al             78      0.00088     -0.00113      0.08425 *
+ * Al             79      0.00368      0.00240     -7.29219 *
+ * Al             80     -0.00476      0.00470      7.29457 *
+ * Al             81      0.00063     -0.00123      0.02961 *
+ * Al             82      0.00092     -0.00110      0.25432 *
+ * Al             83      0.00302      0.00515      0.86503 *
+ * Al             84      0.00026     -0.00672      1.97962 *
+ * Al             85      0.00076     -0.00160     -0.02325 *
+ * Al             86     -0.01320     -0.00180     -0.86346 *
+ * Al             87      0.00720     -0.00143     -1.96932 *
+ * Al             88      0.00118     -0.00123     -0.23295 *
+ * Al             89      0.00078     -0.00101     -0.08235 *
+ * Al             90      0.00118     -0.00088      0.08455 *
+ * Al             91     -0.00684      0.04154     -7.29151 *
+ * Al             92      0.01947      0.01761      7.29427 *
+ * Al             93      0.00083     -0.00090      0.03000 *
+ * Al             94      0.00132     -0.00133      0.25410 *
+ * Al             95     -0.00069     -0.00762      0.85245 *
+ * Al             96      0.01866     -0.00239      1.98458 *
+ * Al             97      0.00045     -0.00100     -0.02321 *
+ * Al             98     -0.01307      0.00382     -0.86060 *
+ * Al             99      0.00414     -0.01155     -1.97357 *
+ * Al            100      0.00108     -0.00070     -0.23295 *
+ * Al            101      0.00069     -0.00116     -0.08206 *
+ * Al            102      0.00105     -0.00077      0.08478 *
+ * Al            103     -0.01061      0.02062     -7.29186 *
+ * Al            104     -0.00511      0.01529      7.29472 *
+ * Al            105      0.00100     -0.00090      0.02975 *
+ * Al            106      0.00102     -0.00147      0.25422 *
+ * Al            107     -0.00442     -0.01625      0.86324 *
+ * Al            108      0.01290     -0.00167      1.98003 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =     12.85 s
+Calculation time    =    217.39 s
+Finalisation time   =      3.43 s
+Total time          =    233.67 s
+Peak Memory Use     = 1307708 kB
+  
+Overall parallel efficiency rating: Terrible (25%)                              
+  
+Data was distributed by:-
+G-vector (256-way); efficiency rating: Terrible (26%)                           
+k-point (2-way); efficiency rating: Excellent (91%)                             
+  
+Parallel notes:
+1) Calculation only took 230.6 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_4nodes_512ranks_1threads_4smp_202109031304_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_4nodes_512ranks_1threads_4smp_202109031304_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:01:48 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 512 processes.
+ Data is distributed by G-vector(256-way) and k-point(2-way)
+ G-vector communication optimised for up to 4-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          4
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      493.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               49.7 MB         0.0 MB |
+| Electronic energy minimisation requirements          27.5 MB         0.0 MB |
+| Force calculation requirements                        0.9 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          570.1 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94040471E+004  0.00000000E+000                         9.51  <-- SCF
+      1  -7.23974364E+004  3.96519365E+000   4.81236640E+001      24.90  <-- SCF
+      2  -7.78239890E+004  1.90527988E+000   2.00983428E+001      35.46  <-- SCF
+      3  -7.79864514E+004  1.80112768E+000   6.01712758E-001      52.75  <-- SCF
+      4  -7.78412701E+004  1.95926701E+000  -5.37708637E-001      65.17  <-- SCF
+      5  -7.77211118E+004  1.34874508E+000  -4.45030685E-001      77.23  <-- SCF
+      6  -7.77152137E+004  1.12183213E+000  -2.18446268E-002      90.50  <-- SCF
+      7  -7.77129476E+004  1.05274255E+000  -8.39298534E-003     102.75  <-- SCF
+      8  -7.77104480E+004  1.02760092E+000  -9.25783876E-003     113.95  <-- SCF
+      9  -7.77084300E+004  9.96413396E-001  -7.47409974E-003     125.76  <-- SCF
+     10  -7.77059702E+004  1.11136371E+000  -9.11059711E-003     137.53  <-- SCF
+     11  -7.77052109E+004  1.16270888E+000  -2.81206666E-003     149.34  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21089850     eV
+Final free energy (E-TS)    =  -77705.21089850     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21089850     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16835      0.02132      0.83077 *
+ * O               2     -0.10063      0.12589      0.83039 *
+ * O               3     -0.06668     -0.15169      0.83441 *
+ * O               4     -0.10532      0.02250      0.37911 *
+ * O               5      0.02443     -0.09659      0.38396 *
+ * O               6      0.07699      0.07308      0.38215 *
+ * O               7     -1.64777      1.74586     -1.01914 *
+ * O               8     -0.68785     -2.29731     -1.02803 *
+ * O               9      2.35044      0.55287     -1.02276 *
+ * O              10      0.08193     -0.01831     -0.39138 *
+ * O              11     -0.02032      0.07676     -0.39128 *
+ * O              12     -0.05695     -0.06644     -0.38820 *
+ * O              13      1.66913     -1.78910      0.95583 *
+ * O              14      0.69898      2.30235      0.96805 *
+ * O              15     -2.35436     -0.54291      0.96720 *
+ * O              16     -0.17019     -0.01542     -0.78243 *
+ * O              17      0.08926     -0.13996     -0.77672 *
+ * O              18      0.07517      0.15829     -0.78480 *
+ * O              19      0.16790      0.02320      0.83960 *
+ * O              20     -0.09889      0.12718      0.83058 *
+ * O              21     -0.05971     -0.14970      0.83328 *
+ * O              22     -0.10370      0.02091      0.38699 *
+ * O              23      0.02643     -0.10073      0.38394 *
+ * O              24      0.07943      0.07042      0.38288 *
+ * O              25     -1.66396      1.77316     -1.01389 *
+ * O              26     -0.68290     -2.29835     -1.02792 *
+ * O              27      2.33970      0.55457     -1.02739 *
+ * O              28      0.08765     -0.01742     -0.38951 *
+ * O              29     -0.02032      0.08024     -0.38994 *
+ * O              30     -0.05797     -0.06299     -0.38791 *
+ * O              31      1.66359     -1.77415      0.96803 *
+ * O              32      0.71062      2.31552      0.96206 *
+ * O              33     -2.38397     -0.55468      0.96195 *
+ * O              34     -0.17672     -0.01832     -0.78697 *
+ * O              35      0.09637     -0.13581     -0.77995 *
+ * O              36      0.07611      0.14664     -0.78445 *
+ * O              37      0.16940      0.01971      0.83519 *
+ * O              38     -0.10504      0.12263      0.83225 *
+ * O              39     -0.05675     -0.15017      0.82985 *
+ * O              40     -0.09756      0.02273      0.38113 *
+ * O              41      0.02957     -0.10024      0.38757 *
+ * O              42      0.07806      0.07544      0.37769 *
+ * O              43     -1.66498      1.77533     -1.01409 *
+ * O              44     -0.68398     -2.29918     -1.02501 *
+ * O              45      2.32885      0.55405     -1.03589 *
+ * O              46      0.08652     -0.01875     -0.39072 *
+ * O              47     -0.02370      0.08221     -0.39008 *
+ * O              48     -0.05562     -0.06487     -0.38865 *
+ * O              49      1.65501     -1.76931      0.96848 *
+ * O              50      0.72159      2.34028      0.96965 *
+ * O              51     -2.38155     -0.55061      0.96161 *
+ * O              52     -0.17400     -0.01233     -0.78629 *
+ * O              53      0.09416     -0.13809     -0.78180 *
+ * O              54      0.07579      0.15374     -0.78137 *
+ * O              55      0.16488      0.02278      0.84126 *
+ * O              56     -0.09807      0.12879      0.83211 *
+ * O              57     -0.05824     -0.15266      0.83351 *
+ * O              58     -0.10185      0.02429      0.38313 *
+ * O              59      0.02319     -0.09934      0.38443 *
+ * O              60      0.07744      0.07775      0.38201 *
+ * O              61     -1.65722      1.76756     -1.02169 *
+ * O              62     -0.69609     -2.31843     -1.02161 *
+ * O              63      2.34362      0.55496     -1.02785 *
+ * O              64      0.08686     -0.01602     -0.39227 *
+ * O              65     -0.02498      0.07757     -0.39069 *
+ * O              66     -0.05945     -0.06479     -0.38650 *
+ * O              67      1.66367     -1.78522      0.96059 *
+ * O              68      0.70247      2.31013      0.97068 *
+ * O              69     -2.32767     -0.54709      0.97360 *
+ * O              70     -0.16848     -0.01246     -0.78307 *
+ * O              71      0.09971     -0.14286     -0.77763 *
+ * O              72      0.07416      0.14821     -0.77862 *
+ * O              73      0.16629      0.02195      0.83642 *
+ * O              74     -0.09947      0.12853      0.82966 *
+ * O              75     -0.05696     -0.15377      0.84076 *
+ * O              76     -0.09820      0.01855      0.38491 *
+ * O              77      0.02364     -0.09944      0.38671 *
+ * O              78      0.07798      0.07640      0.38375 *
+ * O              79     -1.65607      1.75763     -1.02566 *
+ * O              80     -0.68235     -2.29744     -1.02768 *
+ * O              81      2.35297      0.54866     -1.02442 *
+ * O              82      0.08721     -0.01883     -0.38493 *
+ * O              83     -0.01907      0.08136     -0.39269 *
+ * O              84     -0.05805     -0.06566     -0.38414 *
+ * O              85      1.63966     -1.75185      0.96439 *
+ * O              86      0.69725      2.29010      0.97060 *
+ * O              87     -2.37424     -0.54773      0.96405 *
+ * O              88     -0.17561     -0.01085     -0.78613 *
+ * O              89      0.09924     -0.14067     -0.78003 *
+ * O              90      0.07719      0.14924     -0.77732 *
+ * O              91      0.16476      0.02182      0.83800 *
+ * O              92     -0.10069      0.13238      0.83125 *
+ * O              93     -0.06015     -0.15272      0.83324 *
+ * O              94     -0.10095      0.02430      0.38679 *
+ * O              95      0.02661     -0.10031      0.38772 *
+ * O              96      0.07881      0.07316      0.38179 *
+ * O              97     -1.66769      1.77960     -1.02199 *
+ * O              98     -0.68528     -2.28838     -1.02459 *
+ * O              99      2.33291      0.54713     -1.02456 *
+ * O             100      0.08226     -0.01831     -0.39094 *
+ * O             101     -0.01936      0.08062     -0.38609 *
+ * O             102     -0.05820     -0.06428     -0.38701 *
+ * O             103      1.66222     -1.77540      0.96216 *
+ * O             104      0.70039      2.31059      0.96620 *
+ * O             105     -2.37497     -0.54632      0.96661 *
+ * O             106     -0.17533     -0.01311     -0.77903 *
+ * O             107      0.09357     -0.14284     -0.78077 *
+ * O             108      0.07551      0.15057     -0.78639 *
+ * O             109      0.16745      0.01986      0.83588 *
+ * O             110     -0.10046      0.12467      0.83717 *
+ * O             111     -0.05630     -0.15838      0.82886 *
+ * O             112     -0.09887      0.02286      0.37771 *
+ * O             113      0.02494     -0.09828      0.38423 *
+ * O             114      0.07528      0.07408      0.38262 *
+ * O             115     -1.65556      1.75693     -1.02997 *
+ * O             116     -0.69475     -2.30806     -1.02587 *
+ * O             117      2.33792      0.55057     -1.02723 *
+ * O             118      0.08765     -0.01847     -0.38875 *
+ * O             119     -0.02165      0.07990     -0.39214 *
+ * O             120     -0.05943     -0.06601     -0.38907 *
+ * O             121      1.65297     -1.76768      0.96352 *
+ * O             122      0.72157      2.33033      0.95716 *
+ * O             123     -2.34531     -0.54984      0.96773 *
+ * O             124     -0.17228     -0.01129     -0.78050 *
+ * O             125      0.09676     -0.14490     -0.78057 *
+ * O             126      0.07089      0.15337     -0.78177 *
+ * O             127      0.16115      0.02227      0.84185 *
+ * O             128     -0.10303      0.12375      0.83517 *
+ * O             129     -0.05810     -0.15100      0.83411 *
+ * O             130     -0.10364      0.01752      0.38543 *
+ * O             131      0.02277     -0.10447      0.38642 *
+ * O             132      0.07756      0.07049      0.38120 *
+ * O             133     -1.66560      1.77344     -1.01461 *
+ * O             134     -0.69255     -2.32101     -1.02912 *
+ * O             135      2.33280      0.55818     -1.03222 *
+ * O             136      0.08688     -0.01755     -0.39492 *
+ * O             137     -0.02433      0.08009     -0.38899 *
+ * O             138     -0.05851     -0.06502     -0.38376 *
+ * O             139      1.62402     -1.72508      0.95117 *
+ * O             140      0.71286      2.30713      0.95289 *
+ * O             141     -2.38159     -0.55339      0.96411 *
+ * O             142     -0.17286     -0.00948     -0.78728 *
+ * O             143      0.09383     -0.14417     -0.77833 *
+ * O             144      0.07752      0.15183     -0.78278 *
+ * O             145      0.16617      0.01873      0.83873 *
+ * O             146     -0.10322      0.12873      0.83002 *
+ * O             147     -0.05859     -0.15523      0.83770 *
+ * O             148     -0.10135      0.02072      0.38320 *
+ * O             149      0.01960     -0.09942      0.38902 *
+ * O             150      0.07958      0.07330      0.38554 *
+ * O             151     -1.66310      1.76724     -1.00903 *
+ * O             152     -0.67966     -2.28667     -1.02453 *
+ * O             153      2.34833      0.55169     -1.03607 *
+ * O             154      0.08071     -0.01561     -0.39013 *
+ * O             155     -0.02507      0.07975     -0.39310 *
+ * O             156     -0.06092     -0.06568     -0.38658 *
+ * O             157      1.63361     -1.74447      0.95822 *
+ * O             158      0.71478      2.32117      0.96174 *
+ * O             159     -2.38067     -0.54377      0.95644 *
+ * O             160     -0.17900     -0.01507     -0.77755 *
+ * O             161      0.09116     -0.13759     -0.78148 *
+ * O             162      0.07860      0.14787     -0.78267 *
+ * Al              1      0.00113     -0.00116     -0.02327 *
+ * Al              2      0.00082      0.00376     -0.86201 *
+ * Al              3     -0.00027     -0.00565     -1.97540 *
+ * Al              4      0.00085     -0.00077     -0.23276 *
+ * Al              5      0.00010     -0.00116     -0.08241 *
+ * Al              6      0.00120     -0.00106      0.08493 *
+ * Al              7      0.02666     -0.01106     -7.29085 *
+ * Al              8      0.00768      0.00262      7.29526 *
+ * Al              9      0.00132     -0.00117      0.02950 *
+ * Al             10      0.00071     -0.00090      0.25444 *
+ * Al             11     -0.01985      0.00162      0.86616 *
+ * Al             12     -0.00485      0.00462      1.97860 *
+ * Al             13      0.00064     -0.00112     -0.02356 *
+ * Al             14     -0.00506     -0.00691     -0.85683 *
+ * Al             15      0.00571     -0.00717     -1.97135 *
+ * Al             16      0.00090     -0.00074     -0.23312 *
+ * Al             17      0.00081     -0.00115     -0.08228 *
+ * Al             18      0.00075     -0.00072      0.08473 *
+ * Al             19     -0.01501     -0.00275     -7.29191 *
+ * Al             20      0.00207      0.01844      7.29487 *
+ * Al             21      0.00116     -0.00085      0.02983 *
+ * Al             22      0.00146     -0.00142      0.25422 *
+ * Al             23      0.00222     -0.01612      0.86314 *
+ * Al             24      0.00589      0.00442      1.97529 *
+ * Al             25      0.00096     -0.00117     -0.02313 *
+ * Al             26     -0.01771     -0.00112     -0.86572 *
+ * Al             27      0.00962     -0.00524     -1.97527 *
+ * Al             28      0.00091     -0.00048     -0.23298 *
+ * Al             29      0.00049     -0.00102     -0.08246 *
+ * Al             30      0.00142     -0.00096      0.08487 *
+ * Al             31     -0.01157      0.00366     -7.29179 *
+ * Al             32      0.01219      0.01420      7.29319 *
+ * Al             33      0.00125     -0.00087      0.02959 *
+ * Al             34      0.00107     -0.00080      0.25434 *
+ * Al             35     -0.01761     -0.01949      0.87206 *
+ * Al             36      0.00546     -0.00570      1.97151 *
+ * Al             37      0.00090     -0.00097     -0.02306 *
+ * Al             38     -0.00962     -0.00689     -0.86648 *
+ * Al             39      0.00530     -0.00109     -1.97025 *
+ * Al             40      0.00115     -0.00074     -0.23308 *
+ * Al             41      0.00084     -0.00104     -0.08221 *
+ * Al             42      0.00150     -0.00076      0.08487 *
+ * Al             43      0.00360     -0.01428     -7.29226 *
+ * Al             44      0.01179      0.01201      7.29425 *
+ * Al             45      0.00087     -0.00145      0.02973 *
+ * Al             46      0.00105     -0.00116      0.25410 *
+ * Al             47      0.00335      0.00585      0.87102 *
+ * Al             48     -0.00691     -0.00019      1.98260 *
+ * Al             49      0.00147     -0.00131     -0.02336 *
+ * Al             50     -0.00729      0.00195     -0.86273 *
+ * Al             51      0.00137     -0.00843     -1.97298 *
+ * Al             52      0.00121     -0.00075     -0.23266 *
+ * Al             53      0.00048     -0.00125     -0.08234 *
+ * Al             54      0.00105     -0.00075      0.08455 *
+ * Al             55     -0.01819      0.01410     -7.29123 *
+ * Al             56      0.01117      0.01121      7.29484 *
+ * Al             57      0.00072     -0.00124      0.02979 *
+ * Al             58      0.00120     -0.00128      0.25428 *
+ * Al             59      0.01109     -0.00610      0.85700 *
+ * Al             60      0.00802      0.00658      1.98497 *
+ * Al             61      0.00098     -0.00108     -0.02351 *
+ * Al             62     -0.01444     -0.00315     -0.85881 *
+ * Al             63      0.01034     -0.00707     -1.97405 *
+ * Al             64      0.00115     -0.00120     -0.23350 *
+ * Al             65      0.00092     -0.00098     -0.08207 *
+ * Al             66      0.00149     -0.00096      0.08491 *
+ * Al             67     -0.02505     -0.00703     -7.29133 *
+ * Al             68     -0.01102      0.01891      7.29378 *
+ * Al             69      0.00111     -0.00141      0.02981 *
+ * Al             70      0.00126     -0.00106      0.25374 *
+ * Al             71      0.01164     -0.01510      0.86577 *
+ * Al             72      0.00326      0.00486      1.97621 *
+ * Al             73      0.00092     -0.00103     -0.02349 *
+ * Al             74     -0.00178     -0.01070     -0.86212 *
+ * Al             75      0.00334     -0.00319     -1.97216 *
+ * Al             76      0.00051     -0.00085     -0.23300 *
+ * Al             77      0.00049     -0.00098     -0.08267 *
+ * Al             78      0.00088     -0.00113      0.08425 *
+ * Al             79      0.00368      0.00240     -7.29219 *
+ * Al             80     -0.00476      0.00470      7.29457 *
+ * Al             81      0.00063     -0.00123      0.02961 *
+ * Al             82      0.00092     -0.00110      0.25432 *
+ * Al             83      0.00302      0.00515      0.86503 *
+ * Al             84      0.00026     -0.00672      1.97962 *
+ * Al             85      0.00076     -0.00160     -0.02325 *
+ * Al             86     -0.01320     -0.00180     -0.86346 *
+ * Al             87      0.00720     -0.00143     -1.96932 *
+ * Al             88      0.00118     -0.00123     -0.23295 *
+ * Al             89      0.00078     -0.00101     -0.08235 *
+ * Al             90      0.00118     -0.00088      0.08455 *
+ * Al             91     -0.00684      0.04154     -7.29151 *
+ * Al             92      0.01947      0.01761      7.29427 *
+ * Al             93      0.00083     -0.00090      0.03000 *
+ * Al             94      0.00132     -0.00133      0.25410 *
+ * Al             95     -0.00069     -0.00762      0.85245 *
+ * Al             96      0.01866     -0.00239      1.98458 *
+ * Al             97      0.00045     -0.00100     -0.02321 *
+ * Al             98     -0.01307      0.00382     -0.86060 *
+ * Al             99      0.00414     -0.01155     -1.97357 *
+ * Al            100      0.00108     -0.00070     -0.23295 *
+ * Al            101      0.00069     -0.00116     -0.08206 *
+ * Al            102      0.00105     -0.00077      0.08478 *
+ * Al            103     -0.01061      0.02062     -7.29186 *
+ * Al            104     -0.00511      0.01529      7.29472 *
+ * Al            105      0.00100     -0.00090      0.02975 *
+ * Al            106      0.00102     -0.00147      0.25422 *
+ * Al            107     -0.00442     -0.01625      0.86324 *
+ * Al            108      0.01290     -0.00167      1.98003 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      8.70 s
+Calculation time    =    148.21 s
+Finalisation time   =      3.79 s
+Total time          =    160.70 s
+Peak Memory Use     = 1210304 kB
+  
+Overall parallel efficiency rating: Poor (40%)                                  
+  
+Data was distributed by:-
+G-vector (256-way); efficiency rating: Poor (43%)                               
+k-point (2-way); efficiency rating: Excellent (90%)                             
+  
+Parallel notes:
+1) Calculation only took 157.3 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_12smp_202109031348_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_12smp_202109031348_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:46:38 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 12-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :         12
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      493.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          550.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                        10.20  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      23.65  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      32.94  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      42.39  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      53.69  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      64.83  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      77.17  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      88.20  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      99.38  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003     110.44  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     121.35  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     131.46  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      9.49 s
+Calculation time    =    126.17 s
+Finalisation time   =      1.60 s
+Total time          =    137.25 s
+Peak Memory Use     = 1527796 kB
+  
+Overall parallel efficiency rating: Terrible (26%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Terrible (27%)                           
+k-point (2-way); efficiency rating: Excellent (90%)                             
+  
+Parallel notes:
+1) Calculation only took 136.0 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_4smp_202109031321_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_4smp_202109031321_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:18:33 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 4-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          4
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      501.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          558.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                        11.52  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      24.41  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      33.49  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      42.73  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      53.67  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      64.77  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      76.75  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      87.75  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      98.82  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003     109.45  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     120.48  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     130.74  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =     10.66 s
+Calculation time    =    138.05 s
+Finalisation time   =      2.57 s
+Total time          =    151.28 s
+Peak Memory Use     = 1707692 kB
+  
+Overall parallel efficiency rating: Terrible (33%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Poor (35%)                               
+k-point (2-way); efficiency rating: Very good (88%)                             
+  
+Parallel notes:
+1) Calculation only took 149.1 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_8smp_202109031325_mkl.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_MKL-19.5/al3x3_8nodes_1024ranks_1threads_8smp_202109031325_mkl.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Tue, 24 Aug 2021 13:31:22 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: Intel MKL(2019.0.5) (LAPACK version 3.7.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 13:23:16 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 8-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          8
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      501.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          558.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                        13.51  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      25.80  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      34.38  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      42.75  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      53.30  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      63.86  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      74.94  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      85.09  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      94.91  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003     104.89  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     114.62  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     123.78  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =     12.94 s
+Calculation time    =    114.89 s
+Finalisation time   =      1.51 s
+Total time          =    129.34 s
+Peak Memory Use     = 1598576 kB
+  
+Overall parallel efficiency rating: Terrible (27%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Terrible (29%)                           
+k-point (2-way); efficiency rating: Very good (81%)                             
+  
+Parallel notes:
+1) Calculation only took 128.0 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_1nodes_128ranks_1threads_202109031708.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_1nodes_128ranks_1threads_202109031708.castep
@@ -1,0 +1,871 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:03:44 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 128 processes.
+ Data is distributed by G-vector(64-way) and k-point(2-way)
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      457.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                              115.9 MB         0.0 MB |
+| Electronic energy minimisation requirements          81.0 MB         0.0 MB |
+| Force calculation requirements                        3.3 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          653.9 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93881056E+004  0.00000000E+000                         4.30  <-- SCF
+      1  -7.24133231E+004  4.04911021E+000   4.82415463E+001      34.62  <-- SCF
+      2  -7.78242516E+004  1.99533806E+000   2.00404760E+001      57.14  <-- SCF
+      3  -7.79864641E+004  1.80535437E+000   6.00786868E-001      79.69  <-- SCF
+      4  -7.78412676E+004  1.95859791E+000  -5.37764824E-001     105.23  <-- SCF
+      5  -7.77211116E+004  1.34873175E+000  -4.45021993E-001     130.38  <-- SCF
+      6  -7.77152116E+004  1.12173355E+000  -2.18519485E-002     158.28  <-- SCF
+      7  -7.77129481E+004  1.05272514E+000  -8.38337594E-003     183.61  <-- SCF
+      8  -7.77104462E+004  1.02761723E+000  -9.26620045E-003     208.89  <-- SCF
+      9  -7.77084297E+004  9.96411653E-001  -7.46872808E-003     234.02  <-- SCF
+     10  -7.77059729E+004  1.11159090E+000  -9.09932339E-003     258.75  <-- SCF
+     11  -7.77052109E+004  1.16236209E+000  -2.82196285E-003     282.05  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21093039     eV
+Final free energy (E-TS)    =  -77705.21093040     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21093040     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16621      0.02653      0.83811 *
+ * O               2     -0.10177      0.12767      0.83141 *
+ * O               3     -0.06115     -0.15510      0.83910 *
+ * O               4     -0.10355      0.02297      0.38616 *
+ * O               5      0.02235     -0.10160      0.38422 *
+ * O               6      0.07744      0.07662      0.38221 *
+ * O               7     -1.63001      1.73371     -1.01404 *
+ * O               8     -0.69316     -2.29856     -1.02720 *
+ * O               9      2.33602      0.55069     -1.02948 *
+ * O              10      0.09041     -0.01468     -0.39120 *
+ * O              11     -0.02083      0.07720     -0.39231 *
+ * O              12     -0.05752     -0.06393     -0.39420 *
+ * O              13      1.64986     -1.77118      0.95437 *
+ * O              14      0.70805      2.32059      0.96162 *
+ * O              15     -2.37286     -0.55387      0.95936 *
+ * O              16     -0.16949     -0.01155     -0.78589 *
+ * O              17      0.09394     -0.14303     -0.78379 *
+ * O              18      0.07662      0.14784     -0.78674 *
+ * O              19      0.16302      0.02102      0.84546 *
+ * O              20     -0.10388      0.12817      0.84175 *
+ * O              21     -0.06229     -0.15216      0.84129 *
+ * O              22     -0.10213      0.02668      0.38897 *
+ * O              23      0.01666     -0.09804      0.38917 *
+ * O              24      0.07558      0.07538      0.38333 *
+ * O              25     -1.66433      1.77227     -1.02181 *
+ * O              26     -0.71354     -2.34531     -1.01545 *
+ * O              27      2.34471      0.55839     -1.03551 *
+ * O              28      0.08608     -0.01457     -0.38692 *
+ * O              29     -0.02574      0.08311     -0.38883 *
+ * O              30     -0.06086     -0.06317     -0.38845 *
+ * O              31      1.66695     -1.79840      0.95060 *
+ * O              32      0.72416      2.35309      0.95690 *
+ * O              33     -2.35054     -0.54542      0.96179 *
+ * O              34     -0.17160     -0.01330     -0.78541 *
+ * O              35      0.08843     -0.14209     -0.78908 *
+ * O              36      0.07349      0.15301     -0.78915 *
+ * O              37      0.16777      0.02247      0.84726 *
+ * O              38     -0.10388      0.12691      0.84214 *
+ * O              39     -0.05805     -0.15311      0.83857 *
+ * O              40     -0.10385      0.02492      0.38305 *
+ * O              41      0.02287     -0.09984      0.39072 *
+ * O              42      0.07941      0.07455      0.38422 *
+ * O              43     -1.66057      1.77305     -1.01366 *
+ * O              44     -0.68482     -2.28634     -1.02365 *
+ * O              45      2.32084      0.54539     -1.02783 *
+ * O              46      0.08581     -0.01572     -0.38877 *
+ * O              47     -0.02118      0.08447     -0.39649 *
+ * O              48     -0.05903     -0.06248     -0.39338 *
+ * O              49      1.64067     -1.76130      0.96670 *
+ * O              50      0.71012      2.32287      0.95546 *
+ * O              51     -2.31729     -0.54433      0.96854 *
+ * O              52     -0.17197     -0.01557     -0.80172 *
+ * O              53      0.09657     -0.14226     -0.78635 *
+ * O              54      0.07742      0.15751     -0.78219 *
+ * O              55      0.16390      0.02033      0.84788 *
+ * O              56     -0.10110      0.12491      0.83826 *
+ * O              57     -0.06021     -0.15079      0.84027 *
+ * O              58     -0.10166      0.01999      0.38628 *
+ * O              59      0.02596     -0.09872      0.38875 *
+ * O              60      0.07677      0.07399      0.38235 *
+ * O              61     -1.67032      1.77341     -1.00859 *
+ * O              62     -0.67760     -2.27442     -1.02111 *
+ * O              63      2.35579      0.55353     -1.02504 *
+ * O              64      0.08497     -0.01749     -0.38543 *
+ * O              65     -0.02250      0.07420     -0.39510 *
+ * O              66     -0.05957     -0.05995     -0.39583 *
+ * O              67      1.64987     -1.76440      0.96202 *
+ * O              68      0.70664      2.32619      0.96750 *
+ * O              69     -2.35591     -0.55108      0.96864 *
+ * O              70     -0.17442     -0.00707     -0.78954 *
+ * O              71      0.09302     -0.14062     -0.78500 *
+ * O              72      0.07319      0.14719     -0.78326 *
+ * O              73      0.15900      0.01832      0.83856 *
+ * O              74     -0.09997      0.12942      0.83999 *
+ * O              75     -0.06233     -0.15168      0.83856 *
+ * O              76     -0.10024      0.02551      0.38120 *
+ * O              77      0.02256     -0.09350      0.38370 *
+ * O              78      0.08313      0.06748      0.39295 *
+ * O              79     -1.64194      1.74392     -1.02326 *
+ * O              80     -0.69643     -2.29673     -1.02843 *
+ * O              81      2.32239      0.54841     -1.03489 *
+ * O              82      0.08204     -0.01409     -0.39488 *
+ * O              83     -0.01425      0.07849     -0.39563 *
+ * O              84     -0.06140     -0.06481     -0.38975 *
+ * O              85      1.65144     -1.78436      0.95001 *
+ * O              86      0.69320      2.28559      0.96909 *
+ * O              87     -2.33944     -0.54118      0.96933 *
+ * O              88     -0.17156     -0.01481     -0.78411 *
+ * O              89      0.09480     -0.14100     -0.78224 *
+ * O              90      0.06990      0.14752     -0.77861 *
+ * O              91      0.16771      0.02150      0.84529 *
+ * O              92     -0.10428      0.13079      0.83078 *
+ * O              93     -0.05912     -0.14839      0.84177 *
+ * O              94     -0.09839      0.02432      0.38796 *
+ * O              95      0.02174     -0.09908      0.38620 *
+ * O              96      0.07951      0.07358      0.38405 *
+ * O              97     -1.67649      1.78291     -1.01487 *
+ * O              98     -0.70099     -2.32920     -1.02724 *
+ * O              99      2.34766      0.55672     -1.02304 *
+ * O             100      0.08666     -0.01187     -0.38985 *
+ * O             101     -0.02200      0.08231     -0.39833 *
+ * O             102     -0.05928     -0.06084     -0.39109 *
+ * O             103      1.67105     -1.79091      0.96130 *
+ * O             104      0.70316      2.32138      0.96797 *
+ * O             105     -2.36119     -0.54499      0.96166 *
+ * O             106     -0.17802     -0.00974     -0.79025 *
+ * O             107      0.09041     -0.14381     -0.78235 *
+ * O             108      0.07780      0.15037     -0.78196 *
+ * O             109      0.16708      0.01453      0.84024 *
+ * O             110     -0.10917      0.13019      0.83031 *
+ * O             111     -0.06431     -0.15052      0.84002 *
+ * O             112     -0.10020      0.02365      0.38273 *
+ * O             113      0.02657     -0.09687      0.38184 *
+ * O             114      0.07662      0.07333      0.38585 *
+ * O             115     -1.67860      1.77994     -1.01419 *
+ * O             116     -0.67912     -2.28673     -1.01872 *
+ * O             117      2.33993      0.55168     -1.02102 *
+ * O             118      0.08530     -0.01822     -0.38988 *
+ * O             119     -0.02071      0.08119     -0.39319 *
+ * O             120     -0.05643     -0.06308     -0.38429 *
+ * O             121      1.65322     -1.77208      0.95406 *
+ * O             122      0.71836      2.33750      0.95345 *
+ * O             123     -2.35222     -0.54754      0.96704 *
+ * O             124     -0.17749     -0.01014     -0.78767 *
+ * O             125      0.09600     -0.13934     -0.78533 *
+ * O             126      0.07330      0.14794     -0.78733 *
+ * O             127      0.16569      0.02249      0.84263 *
+ * O             128     -0.10465      0.11997      0.84010 *
+ * O             129     -0.06191     -0.15002      0.83203 *
+ * O             130     -0.10223      0.02693      0.38394 *
+ * O             131      0.02387     -0.10266      0.38530 *
+ * O             132      0.07560      0.07167      0.38713 *
+ * O             133     -1.65983      1.76485     -1.01820 *
+ * O             134     -0.69340     -2.30243     -1.03106 *
+ * O             135      2.34233      0.55306     -1.02691 *
+ * O             136      0.08209     -0.01941     -0.39278 *
+ * O             137     -0.02315      0.08217     -0.39096 *
+ * O             138     -0.05488     -0.06348     -0.39273 *
+ * O             139      1.64244     -1.76522      0.96164 *
+ * O             140      0.70519      2.31633      0.95736 *
+ * O             141     -2.34418     -0.54508      0.96783 *
+ * O             142     -0.17045     -0.01035     -0.78978 *
+ * O             143      0.09434     -0.14344     -0.77862 *
+ * O             144      0.07562      0.15079     -0.78275 *
+ * O             145      0.16270      0.02326      0.84460 *
+ * O             146     -0.10144      0.12797      0.83921 *
+ * O             147     -0.06229     -0.14740      0.83614 *
+ * O             148     -0.10028      0.02909      0.38743 *
+ * O             149      0.02512     -0.09638      0.38642 *
+ * O             150      0.07870      0.07369      0.38721 *
+ * O             151     -1.66595      1.76756     -1.02043 *
+ * O             152     -0.69581     -2.31614     -1.02418 *
+ * O             153      2.35492      0.55316     -1.03043 *
+ * O             154      0.08564     -0.01625     -0.39002 *
+ * O             155     -0.02331      0.08092     -0.39077 *
+ * O             156     -0.05789     -0.06382     -0.39129 *
+ * O             157      1.66055     -1.78589      0.95289 *
+ * O             158      0.69341      2.27608      0.96873 *
+ * O             159     -2.37480     -0.54086      0.95207 *
+ * O             160     -0.17106     -0.01635     -0.78764 *
+ * O             161      0.09942     -0.14117     -0.78261 *
+ * O             162      0.07297      0.15065     -0.79144 *
+ * Al              1      0.00022     -0.00110     -0.02072 *
+ * Al              2      0.00190      0.01149     -0.86940 *
+ * Al              3     -0.00500     -0.00013     -1.97827 *
+ * Al              4      0.00043     -0.00014     -0.23075 *
+ * Al              5     -0.00002     -0.00096     -0.08320 *
+ * Al              6      0.00052     -0.00053      0.08476 *
+ * Al              7      0.00433      0.00273     -7.29036 *
+ * Al              8     -0.01562     -0.02322      7.29261 *
+ * Al              9      0.00033     -0.00059      0.02753 *
+ * Al             10      0.00016     -0.00052      0.25180 *
+ * Al             11      0.00376     -0.00017      0.85614 *
+ * Al             12      0.00220      0.00050      1.97669 *
+ * Al             13      0.00023     -0.00027     -0.02124 *
+ * Al             14     -0.00862     -0.00477     -0.86012 *
+ * Al             15      0.00349      0.00460     -1.96160 *
+ * Al             16     -0.00007     -0.00089     -0.23104 *
+ * Al             17     -0.00040     -0.00089     -0.08273 *
+ * Al             18      0.00014     -0.00060      0.08519 *
+ * Al             19      0.01014     -0.01665     -7.29042 *
+ * Al             20      0.01051      0.01676      7.29401 *
+ * Al             21      0.00001     -0.00065      0.02684 *
+ * Al             22      0.00042      0.00009      0.25199 *
+ * Al             23      0.00062      0.00480      0.86559 *
+ * Al             24     -0.00698     -0.00893      1.96895 *
+ * Al             25      0.00027     -0.00045     -0.02085 *
+ * Al             26     -0.00709     -0.00473     -0.85674 *
+ * Al             27      0.00890     -0.00642     -1.97610 *
+ * Al             28     -0.00001     -0.00072     -0.23082 *
+ * Al             29     -0.00033     -0.00064     -0.08285 *
+ * Al             30      0.00028     -0.00081      0.08453 *
+ * Al             31      0.02131      0.01488     -7.28989 *
+ * Al             32      0.00561      0.01259      7.29194 *
+ * Al             33      0.00085     -0.00112      0.02680 *
+ * Al             34     -0.00014     -0.00092      0.25199 *
+ * Al             35     -0.01512      0.02046      0.86297 *
+ * Al             36     -0.00483     -0.00770      1.98478 *
+ * Al             37      0.00021     -0.00089     -0.02055 *
+ * Al             38     -0.01324     -0.01218     -0.86130 *
+ * Al             39      0.00484     -0.01283     -1.97198 *
+ * Al             40      0.00040     -0.00055     -0.23132 *
+ * Al             41     -0.00005     -0.00051     -0.08259 *
+ * Al             42      0.00065     -0.00130      0.08501 *
+ * Al             43      0.00318      0.00169     -7.29140 *
+ * Al             44      0.00189      0.01501      7.29172 *
+ * Al             45      0.00037     -0.00090      0.02672 *
+ * Al             46      0.00012     -0.00067      0.25138 *
+ * Al             47     -0.00400     -0.00135      0.86494 *
+ * Al             48      0.00074     -0.00187      1.97936 *
+ * Al             49      0.00020     -0.00121     -0.02113 *
+ * Al             50      0.01480     -0.00634     -0.85597 *
+ * Al             51      0.00084      0.00027     -1.97634 *
+ * Al             52      0.00050     -0.00040     -0.23085 *
+ * Al             53      0.00010     -0.00066     -0.08251 *
+ * Al             54      0.00051     -0.00069      0.08459 *
+ * Al             55      0.00663     -0.00893     -7.28985 *
+ * Al             56     -0.00552     -0.00996      7.29424 *
+ * Al             57      0.00063     -0.00102      0.02721 *
+ * Al             58      0.00007     -0.00030      0.25183 *
+ * Al             59     -0.00032      0.00715      0.86635 *
+ * Al             60     -0.00733      0.00564      1.98478 *
+ * Al             61      0.00008     -0.00099     -0.02103 *
+ * Al             62     -0.01846     -0.00026     -0.85944 *
+ * Al             63      0.00708     -0.00082     -1.96342 *
+ * Al             64      0.00023     -0.00056     -0.23059 *
+ * Al             65     -0.00037     -0.00080     -0.08287 *
+ * Al             66      0.00049     -0.00089      0.08499 *
+ * Al             67     -0.01759     -0.02179     -7.28975 *
+ * Al             68      0.00508      0.03258      7.29389 *
+ * Al             69     -0.00044     -0.00135      0.02679 *
+ * Al             70      0.00090     -0.00002      0.25187 *
+ * Al             71      0.01791     -0.00075      0.86602 *
+ * Al             72     -0.00701      0.00150      1.97441 *
+ * Al             73      0.00015     -0.00043     -0.02117 *
+ * Al             74     -0.02452      0.00084     -0.86197 *
+ * Al             75      0.00846     -0.00918     -1.97144 *
+ * Al             76      0.00029     -0.00067     -0.23111 *
+ * Al             77     -0.00030     -0.00094     -0.08260 *
+ * Al             78      0.00037     -0.00093      0.08499 *
+ * Al             79     -0.02364     -0.01095     -7.29180 *
+ * Al             80      0.00638      0.01794      7.29191 *
+ * Al             81     -0.00023     -0.00082      0.02675 *
+ * Al             82      0.00035     -0.00088      0.25152 *
+ * Al             83      0.02400     -0.00375      0.86645 *
+ * Al             84     -0.00055     -0.00515      1.97525 *
+ * Al             85     -0.00015     -0.00117     -0.02122 *
+ * Al             86     -0.00449      0.00179     -0.85834 *
+ * Al             87      0.00268     -0.00391     -1.97119 *
+ * Al             88      0.00016     -0.00092     -0.23068 *
+ * Al             89      0.00030     -0.00100     -0.08269 *
+ * Al             90      0.00022     -0.00056      0.08505 *
+ * Al             91      0.01528      0.00716     -7.29120 *
+ * Al             92     -0.00592      0.00715      7.29385 *
+ * Al             93     -0.00007     -0.00071      0.02653 *
+ * Al             94      0.00038     -0.00087      0.25156 *
+ * Al             95     -0.00820      0.00709      0.86245 *
+ * Al             96     -0.00092     -0.00272      1.98175 *
+ * Al             97     -0.00013     -0.00074     -0.02089 *
+ * Al             98     -0.00116     -0.01206     -0.85692 *
+ * Al             99      0.00336     -0.00332     -1.96743 *
+ * Al            100      0.00033     -0.00079     -0.23041 *
+ * Al            101     -0.00024     -0.00115     -0.08307 *
+ * Al            102      0.00064     -0.00061      0.08427 *
+ * Al            103      0.01676     -0.01735     -7.29068 *
+ * Al            104      0.00966      0.01783      7.29412 *
+ * Al            105      0.00060     -0.00137      0.02685 *
+ * Al            106      0.00004     -0.00083      0.25183 *
+ * Al            107      0.00484     -0.00276      0.85883 *
+ * Al            108     -0.00180      0.01267      1.98009 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      3.26 s
+Calculation time    =    305.20 s
+Finalisation time   =      2.15 s
+Total time          =    310.60 s
+Peak Memory Use     = 1226132 kB
+  
+Overall parallel efficiency rating: Good (70%)                                  
+  
+Data was distributed by:-
+G-vector (64-way); efficiency rating: Good (72%)                                
+k-point (2-way); efficiency rating: Excellent (97%)                             
+  
+Parallel notes:
+1) Calculation only took 308.5 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_2nodes_256ranks_1threads_202109031707.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_2nodes_256ranks_1threads_202109031707.castep
@@ -1,0 +1,871 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:04:19 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 256 processes.
+ Data is distributed by G-vector(128-way) and k-point(2-way)
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      463.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               71.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          45.2 MB         0.0 MB |
+| Force calculation requirements                        1.7 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          579.8 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.93903962E+004  0.00000000E+000                         3.02  <-- SCF
+      1  -7.24025078E+004  4.04952038E+000   4.81930060E+001      22.49  <-- SCF
+      2  -7.78252467E+004  1.95718735E+000   2.00842181E+001      37.12  <-- SCF
+      3  -7.79864690E+004  1.80210546E+000   5.97119548E-001      51.79  <-- SCF
+      4  -7.78412511E+004  1.95866797E+000  -5.37843840E-001      68.10  <-- SCF
+      5  -7.77211110E+004  1.34858550E+000  -4.44963492E-001      84.04  <-- SCF
+      6  -7.77152160E+004  1.12181373E+000  -2.18332198E-002     101.67  <-- SCF
+      7  -7.77129479E+004  1.05270612E+000  -8.40047628E-003     117.64  <-- SCF
+      8  -7.77104474E+004  1.02757566E+000  -9.26117241E-003     133.67  <-- SCF
+      9  -7.77084302E+004  9.96440502E-001  -7.47088452E-003     149.61  <-- SCF
+     10  -7.77059868E+004  1.11158438E+000  -9.04964605E-003     165.25  <-- SCF
+     11  -7.77052160E+004  1.16142631E+000  -2.85493552E-003     180.07  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21598074     eV
+Final free energy (E-TS)    =  -77705.21598074     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21598074     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16546      0.02416      0.81294 *
+ * O               2     -0.09616      0.12867      0.80709 *
+ * O               3     -0.06588     -0.14994      0.81406 *
+ * O               4     -0.10281      0.02695      0.37080 *
+ * O               5      0.02296     -0.10533      0.37258 *
+ * O               6      0.08183      0.07481      0.36653 *
+ * O               7     -1.64065      1.74452     -1.02151 *
+ * O               8     -0.69944     -2.30209     -1.02675 *
+ * O               9      2.35342      0.54882     -1.03858 *
+ * O              10      0.08666     -0.01690     -0.37847 *
+ * O              11     -0.02365      0.08637     -0.38175 *
+ * O              12     -0.06099     -0.06281     -0.37824 *
+ * O              13      1.64860     -1.77868      0.96839 *
+ * O              14      0.68951      2.28569      0.96500 *
+ * O              15     -2.33669     -0.53356      0.96999 *
+ * O              16     -0.17547     -0.00725     -0.76416 *
+ * O              17      0.09752     -0.14298     -0.75951 *
+ * O              18      0.07425      0.15725     -0.76225 *
+ * O              19      0.16803      0.01920      0.82015 *
+ * O              20     -0.10362      0.12991      0.81354 *
+ * O              21     -0.06580     -0.14472      0.81601 *
+ * O              22     -0.10143      0.02835      0.36943 *
+ * O              23      0.02263     -0.10179      0.36864 *
+ * O              24      0.07665      0.07523      0.36866 *
+ * O              25     -1.66701      1.77075     -1.03492 *
+ * O              26     -0.68684     -2.29542     -1.03275 *
+ * O              27      2.35749      0.55462     -1.04283 *
+ * O              28      0.08133     -0.01980     -0.37850 *
+ * O              29     -0.02038      0.07898     -0.37860 *
+ * O              30     -0.06232     -0.06315     -0.37473 *
+ * O              31      1.66467     -1.78624      0.98469 *
+ * O              32      0.69482      2.29819      0.97034 *
+ * O              33     -2.34814     -0.54040      0.97956 *
+ * O              34     -0.17813     -0.00834     -0.76088 *
+ * O              35      0.09778     -0.14689     -0.76193 *
+ * O              36      0.07469      0.14838     -0.75826 *
+ * O              37      0.16990      0.01744      0.81425 *
+ * O              38     -0.10322      0.13320      0.81620 *
+ * O              39     -0.06402     -0.14920      0.80926 *
+ * O              40     -0.10523      0.02895      0.36732 *
+ * O              41      0.02687     -0.10466      0.37168 *
+ * O              42      0.07885      0.07157      0.36777 *
+ * O              43     -1.65142      1.75208     -1.02511 *
+ * O              44     -0.67866     -2.26635     -1.02038 *
+ * O              45      2.32009      0.54255     -1.03354 *
+ * O              46      0.08567     -0.01931     -0.37815 *
+ * O              47     -0.02418      0.08385     -0.37607 *
+ * O              48     -0.06439     -0.07142     -0.37582 *
+ * O              49      1.65950     -1.78526      0.97844 *
+ * O              50      0.71527      2.33420      0.97835 *
+ * O              51     -2.35868     -0.55374      0.98680 *
+ * O              52     -0.18085     -0.00531     -0.76635 *
+ * O              53      0.08977     -0.14089     -0.75906 *
+ * O              54      0.07611      0.15385     -0.75937 *
+ * O              55      0.16552      0.02106      0.81218 *
+ * O              56     -0.09856      0.13065      0.81277 *
+ * O              57     -0.06654     -0.14702      0.81294 *
+ * O              58     -0.10475      0.02844      0.36868 *
+ * O              59      0.01967     -0.10042      0.36962 *
+ * O              60      0.07989      0.07861      0.37000 *
+ * O              61     -1.65968      1.75848     -1.03018 *
+ * O              62     -0.68769     -2.30129     -1.03344 *
+ * O              63      2.35685      0.55275     -1.03609 *
+ * O              64      0.08668     -0.02116     -0.37511 *
+ * O              65     -0.02570      0.08176     -0.37275 *
+ * O              66     -0.05911     -0.06669     -0.37544 *
+ * O              67      1.65481     -1.78908      0.96737 *
+ * O              68      0.71009      2.32141      0.98285 *
+ * O              69     -2.31933     -0.54483      0.96963 *
+ * O              70     -0.17787     -0.00847     -0.76529 *
+ * O              71      0.09221     -0.14549     -0.76050 *
+ * O              72      0.06899      0.15308     -0.75638 *
+ * O              73      0.16702      0.01837      0.81739 *
+ * O              74     -0.10637      0.12860      0.81480 *
+ * O              75     -0.06197     -0.14239      0.80796 *
+ * O              76     -0.10208      0.02283      0.37012 *
+ * O              77      0.02311     -0.09999      0.36896 *
+ * O              78      0.08211      0.07316      0.36810 *
+ * O              79     -1.66020      1.76919     -1.03916 *
+ * O              80     -0.67806     -2.27901     -1.02993 *
+ * O              81      2.33916      0.54795     -1.03526 *
+ * O              82      0.08936     -0.02147     -0.37745 *
+ * O              83     -0.02639      0.08276     -0.37780 *
+ * O              84     -0.06329     -0.06518     -0.36829 *
+ * O              85      1.65560     -1.78969      0.96722 *
+ * O              86      0.70254      2.30598      0.97685 *
+ * O              87     -2.34465     -0.54666      0.96698 *
+ * O              88     -0.17293     -0.00848     -0.76817 *
+ * O              89      0.09630     -0.14464     -0.75764 *
+ * O              90      0.07138      0.15107     -0.75894 *
+ * O              91      0.16735      0.01663      0.82123 *
+ * O              92     -0.10911      0.13678      0.81157 *
+ * O              93     -0.06170     -0.15214      0.81698 *
+ * O              94     -0.10212      0.02481      0.36797 *
+ * O              95      0.02111     -0.10135      0.36935 *
+ * O              96      0.07746      0.07536      0.36864 *
+ * O              97     -1.66988      1.78799     -1.03528 *
+ * O              98     -0.66620     -2.27077     -1.03039 *
+ * O              99      2.32370      0.54669     -1.03516 *
+ * O             100      0.08858     -0.01767     -0.37297 *
+ * O             101     -0.02631      0.08071     -0.38044 *
+ * O             102     -0.06074     -0.06512     -0.37196 *
+ * O             103      1.66071     -1.78210      0.97030 *
+ * O             104      0.70311      2.31046      0.97547 *
+ * O             105     -2.37508     -0.55130      0.98659 *
+ * O             106     -0.17525     -0.00607     -0.76032 *
+ * O             107      0.09430     -0.14549     -0.76220 *
+ * O             108      0.07652      0.15240     -0.76702 *
+ * O             109      0.16770      0.02197      0.81295 *
+ * O             110     -0.10397      0.12921      0.81519 *
+ * O             111     -0.06285     -0.15522      0.81006 *
+ * O             112     -0.10382      0.02365      0.37140 *
+ * O             113      0.02148     -0.10270      0.37550 *
+ * O             114      0.08026      0.07652      0.36248 *
+ * O             115     -1.65021      1.75632     -1.02690 *
+ * O             116     -0.70342     -2.31655     -1.03751 *
+ * O             117      2.33268      0.55807     -1.03652 *
+ * O             118      0.08556     -0.01931     -0.37638 *
+ * O             119     -0.02034      0.07755     -0.38030 *
+ * O             120     -0.06360     -0.06058     -0.37443 *
+ * O             121      1.66643     -1.80035      0.97018 *
+ * O             122      0.68999      2.29754      0.96803 *
+ * O             123     -2.34524     -0.53677      0.97302 *
+ * O             124     -0.17507     -0.01129     -0.75964 *
+ * O             125      0.09898     -0.14420     -0.75595 *
+ * O             126      0.07415      0.14959     -0.75966 *
+ * O             127      0.16525      0.02368      0.81186 *
+ * O             128     -0.10479      0.13126      0.80929 *
+ * O             129     -0.06465     -0.15763      0.81518 *
+ * O             130     -0.10227      0.02545      0.37047 *
+ * O             131      0.01998     -0.09627      0.37630 *
+ * O             132      0.08079      0.07477      0.36651 *
+ * O             133     -1.64940      1.74972     -1.02330 *
+ * O             134     -0.69023     -2.29459     -1.03307 *
+ * O             135      2.34930      0.55350     -1.02752 *
+ * O             136      0.08386     -0.01598     -0.37672 *
+ * O             137     -0.02294      0.08197     -0.37920 *
+ * O             138     -0.06341     -0.06418     -0.37632 *
+ * O             139      1.65271     -1.78630      0.96586 *
+ * O             140      0.70847      2.31134      0.97245 *
+ * O             141     -2.32936     -0.54124      0.97518 *
+ * O             142     -0.17634     -0.00981     -0.76434 *
+ * O             143      0.09137     -0.14797     -0.75737 *
+ * O             144      0.07406      0.15113     -0.75596 *
+ * O             145      0.16638      0.01935      0.82375 *
+ * O             146     -0.10430      0.12987      0.81009 *
+ * O             147     -0.06201     -0.15279      0.81788 *
+ * O             148     -0.10736      0.02817      0.36977 *
+ * O             149      0.01937     -0.10353      0.37244 *
+ * O             150      0.08096      0.07919      0.36409 *
+ * O             151     -1.67022      1.77885     -1.03871 *
+ * O             152     -0.69352     -2.30889     -1.03448 *
+ * O             153      2.34004      0.55637     -1.03928 *
+ * O             154      0.08674     -0.02108     -0.37915 *
+ * O             155     -0.02409      0.08379     -0.37762 *
+ * O             156     -0.06030     -0.06568     -0.37517 *
+ * O             157      1.63441     -1.76513      0.96626 *
+ * O             158      0.70166      2.29769      0.97129 *
+ * O             159     -2.33831     -0.54053      0.97307 *
+ * O             160     -0.17590     -0.01411     -0.76733 *
+ * O             161      0.09602     -0.14378     -0.75459 *
+ * O             162      0.07671      0.15656     -0.75454 *
+ * Al              1     -0.00078     -0.00043     -0.04369 *
+ * Al              2      0.00926     -0.00399     -0.87355 *
+ * Al              3     -0.00637     -0.00298     -1.98218 *
+ * Al              4     -0.00020     -0.00010     -0.25108 *
+ * Al              5     -0.00120     -0.00024     -0.08070 *
+ * Al              6      0.00003     -0.00014      0.08247 *
+ * Al              7      0.03002     -0.01215     -7.29639 *
+ * Al              8      0.00646     -0.00218      7.29946 *
+ * Al              9     -0.00076     -0.00054      0.05061 *
+ * Al             10     -0.00071      0.00022      0.27267 *
+ * Al             11     -0.00823      0.01285      0.87455 *
+ * Al             12     -0.00885      0.00687      1.99500 *
+ * Al             13     -0.00049      0.00005     -0.04377 *
+ * Al             14     -0.01552     -0.00249     -0.87068 *
+ * Al             15      0.00087     -0.01006     -1.97477 *
+ * Al             16     -0.00062      0.00001     -0.25146 *
+ * Al             17     -0.00111     -0.00029     -0.08042 *
+ * Al             18     -0.00080     -0.00017      0.08222 *
+ * Al             19     -0.00509     -0.03543     -7.29645 *
+ * Al             20      0.02396      0.02835      7.29835 *
+ * Al             21     -0.00072     -0.00021      0.04990 *
+ * Al             22     -0.00050     -0.00007      0.27267 *
+ * Al             23      0.02522      0.00225      0.87336 *
+ * Al             24     -0.00862      0.00815      1.98594 *
+ * Al             25     -0.00077     -0.00045     -0.04390 *
+ * Al             26     -0.00271      0.00076     -0.86818 *
+ * Al             27      0.00439     -0.00935     -1.99067 *
+ * Al             28     -0.00035      0.00006     -0.25129 *
+ * Al             29     -0.00115     -0.00040     -0.08057 *
+ * Al             30     -0.00018     -0.00020      0.08239 *
+ * Al             31     -0.02118     -0.01098     -7.29790 *
+ * Al             32     -0.00018      0.00968      7.29821 *
+ * Al             33     -0.00083     -0.00034      0.05065 *
+ * Al             34     -0.00053      0.00028      0.27314 *
+ * Al             35      0.01159     -0.00273      0.87343 *
+ * Al             36     -0.00366     -0.00221      1.97997 *
+ * Al             37     -0.00045      0.00035     -0.04412 *
+ * Al             38     -0.00904     -0.00690     -0.87351 *
+ * Al             39     -0.00145     -0.00690     -1.97769 *
+ * Al             40     -0.00085     -0.00016     -0.25208 *
+ * Al             41     -0.00129     -0.00044     -0.08077 *
+ * Al             42     -0.00045     -0.00034      0.08224 *
+ * Al             43      0.00410     -0.01786     -7.29639 *
+ * Al             44      0.02573      0.01542      7.29844 *
+ * Al             45     -0.00070     -0.00057      0.05013 *
+ * Al             46     -0.00036      0.00008      0.27287 *
+ * Al             47      0.00883      0.01632      0.87882 *
+ * Al             48     -0.01272     -0.00637      1.98656 *
+ * Al             49     -0.00038     -0.00033     -0.04452 *
+ * Al             50     -0.01665      0.00590     -0.86546 *
+ * Al             51      0.00572     -0.01113     -1.98258 *
+ * Al             52     -0.00081     -0.00003     -0.25146 *
+ * Al             53     -0.00062     -0.00018     -0.08061 *
+ * Al             54     -0.00040     -0.00020      0.08231 *
+ * Al             55      0.02393     -0.01478     -7.29675 *
+ * Al             56      0.03001      0.02566      7.29862 *
+ * Al             57     -0.00065     -0.00042      0.05014 *
+ * Al             58     -0.00048     -0.00006      0.27288 *
+ * Al             59     -0.00118      0.01578      0.87015 *
+ * Al             60     -0.01039      0.00217      1.98744 *
+ * Al             61     -0.00055     -0.00024     -0.04389 *
+ * Al             62     -0.03206      0.01001     -0.86646 *
+ * Al             63      0.01268     -0.01222     -1.98330 *
+ * Al             64      0.00010     -0.00003     -0.25147 *
+ * Al             65     -0.00104     -0.00031     -0.08071 *
+ * Al             66     -0.00010     -0.00023      0.08232 *
+ * Al             67      0.00360     -0.01448     -7.29741 *
+ * Al             68     -0.00408      0.03647      7.29786 *
+ * Al             69     -0.00072     -0.00039      0.05038 *
+ * Al             70     -0.00022     -0.00019      0.27280 *
+ * Al             71      0.01301     -0.00398      0.86429 *
+ * Al             72     -0.00020      0.00619      1.98180 *
+ * Al             73     -0.00149     -0.00029     -0.04385 *
+ * Al             74     -0.00710     -0.00615     -0.87802 *
+ * Al             75      0.00071      0.00306     -1.97929 *
+ * Al             76     -0.00102      0.00046     -0.25137 *
+ * Al             77     -0.00124     -0.00045     -0.08055 *
+ * Al             78     -0.00027      0.00033      0.08279 *
+ * Al             79      0.00570     -0.03329     -7.29560 *
+ * Al             80      0.01587      0.00295      7.29848 *
+ * Al             81     -0.00081     -0.00046      0.05017 *
+ * Al             82     -0.00094     -0.00022      0.27293 *
+ * Al             83      0.01047      0.00515      0.87591 *
+ * Al             84     -0.01200      0.00939      1.98706 *
+ * Al             85     -0.00056     -0.00027     -0.04383 *
+ * Al             86     -0.00974      0.01498     -0.87595 *
+ * Al             87     -0.00294     -0.00439     -1.98352 *
+ * Al             88     -0.00051     -0.00000     -0.25120 *
+ * Al             89     -0.00117     -0.00046     -0.08056 *
+ * Al             90     -0.00093     -0.00020      0.08261 *
+ * Al             91     -0.01021     -0.01956     -7.29632 *
+ * Al             92     -0.00386     -0.00232      7.29874 *
+ * Al             93     -0.00050     -0.00027      0.04968 *
+ * Al             94     -0.00055     -0.00008      0.27253 *
+ * Al             95      0.01620      0.00799      0.87912 *
+ * Al             96     -0.00911     -0.00067      1.98860 *
+ * Al             97     -0.00080     -0.00027     -0.04371 *
+ * Al             98     -0.02463      0.00092     -0.87414 *
+ * Al             99      0.00658     -0.00166     -1.97613 *
+ * Al            100     -0.00040     -0.00062     -0.25166 *
+ * Al            101     -0.00141     -0.00018     -0.08041 *
+ * Al            102     -0.00053     -0.00013      0.08256 *
+ * Al            103     -0.00222      0.00384     -7.29675 *
+ * Al            104     -0.01906      0.01852      7.29852 *
+ * Al            105     -0.00048     -0.00059      0.05006 *
+ * Al            106     -0.00045     -0.00066      0.27289 *
+ * Al            107      0.00856      0.01037      0.87084 *
+ * Al            108     -0.00299      0.00157      1.99364 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.53 s
+Calculation time    =    191.10 s
+Finalisation time   =      3.63 s
+Total time          =    197.27 s
+Peak Memory Use     = 1376336 kB
+  
+Overall parallel efficiency rating: Mediocre (59%)                              
+  
+Data was distributed by:-
+G-vector (128-way); efficiency rating: Satisfactory (61%)                       
+k-point (2-way); efficiency rating: Excellent (97%)                             
+  
+Parallel notes:
+1) Calculation only took 193.6 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_4nodes_512ranks_1threads_4smp_202109031710.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_4nodes_512ranks_1threads_4smp_202109031710.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:07:52 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 512 processes.
+ Data is distributed by G-vector(256-way) and k-point(2-way)
+ G-vector communication optimised for up to 4-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          4
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      473.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               49.7 MB         0.0 MB |
+| Electronic energy minimisation requirements          27.5 MB         0.0 MB |
+| Force calculation requirements                        0.9 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          550.1 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94040471E+004  0.00000000E+000                         3.00  <-- SCF
+      1  -7.23974364E+004  3.96519365E+000   4.81236640E+001      18.88  <-- SCF
+      2  -7.78239890E+004  1.90527988E+000   2.00983428E+001      29.96  <-- SCF
+      3  -7.79864514E+004  1.80112768E+000   6.01712758E-001      41.21  <-- SCF
+      4  -7.78412701E+004  1.95926701E+000  -5.37708637E-001      54.40  <-- SCF
+      5  -7.77211118E+004  1.34874508E+000  -4.45030685E-001      67.56  <-- SCF
+      6  -7.77152137E+004  1.12183213E+000  -2.18446268E-002      81.64  <-- SCF
+      7  -7.77129476E+004  1.05274255E+000  -8.39298534E-003      94.95  <-- SCF
+      8  -7.77104480E+004  1.02760092E+000  -9.25783876E-003     107.33  <-- SCF
+      9  -7.77084300E+004  9.96413396E-001  -7.47409974E-003     120.17  <-- SCF
+     10  -7.77059702E+004  1.11136371E+000  -9.11059711E-003     132.81  <-- SCF
+     11  -7.77052109E+004  1.16270888E+000  -2.81206666E-003     145.58  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.21089850     eV
+Final free energy (E-TS)    =  -77705.21089850     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.21089850     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16835      0.02132      0.83077 *
+ * O               2     -0.10063      0.12589      0.83039 *
+ * O               3     -0.06668     -0.15169      0.83441 *
+ * O               4     -0.10532      0.02250      0.37911 *
+ * O               5      0.02443     -0.09659      0.38396 *
+ * O               6      0.07699      0.07308      0.38215 *
+ * O               7     -1.64777      1.74586     -1.01914 *
+ * O               8     -0.68785     -2.29731     -1.02803 *
+ * O               9      2.35044      0.55287     -1.02276 *
+ * O              10      0.08193     -0.01831     -0.39138 *
+ * O              11     -0.02032      0.07676     -0.39128 *
+ * O              12     -0.05695     -0.06644     -0.38820 *
+ * O              13      1.66913     -1.78910      0.95583 *
+ * O              14      0.69898      2.30235      0.96805 *
+ * O              15     -2.35436     -0.54291      0.96720 *
+ * O              16     -0.17019     -0.01542     -0.78243 *
+ * O              17      0.08926     -0.13996     -0.77672 *
+ * O              18      0.07517      0.15829     -0.78480 *
+ * O              19      0.16790      0.02320      0.83960 *
+ * O              20     -0.09889      0.12718      0.83058 *
+ * O              21     -0.05971     -0.14970      0.83328 *
+ * O              22     -0.10370      0.02091      0.38699 *
+ * O              23      0.02643     -0.10073      0.38394 *
+ * O              24      0.07943      0.07042      0.38288 *
+ * O              25     -1.66396      1.77316     -1.01389 *
+ * O              26     -0.68290     -2.29835     -1.02792 *
+ * O              27      2.33970      0.55457     -1.02739 *
+ * O              28      0.08765     -0.01742     -0.38951 *
+ * O              29     -0.02032      0.08024     -0.38994 *
+ * O              30     -0.05797     -0.06299     -0.38791 *
+ * O              31      1.66359     -1.77415      0.96803 *
+ * O              32      0.71062      2.31552      0.96206 *
+ * O              33     -2.38397     -0.55468      0.96195 *
+ * O              34     -0.17672     -0.01832     -0.78697 *
+ * O              35      0.09637     -0.13581     -0.77995 *
+ * O              36      0.07611      0.14664     -0.78445 *
+ * O              37      0.16940      0.01971      0.83519 *
+ * O              38     -0.10504      0.12263      0.83225 *
+ * O              39     -0.05675     -0.15017      0.82985 *
+ * O              40     -0.09756      0.02273      0.38113 *
+ * O              41      0.02957     -0.10024      0.38757 *
+ * O              42      0.07806      0.07544      0.37769 *
+ * O              43     -1.66498      1.77533     -1.01409 *
+ * O              44     -0.68398     -2.29918     -1.02501 *
+ * O              45      2.32885      0.55405     -1.03589 *
+ * O              46      0.08652     -0.01875     -0.39072 *
+ * O              47     -0.02370      0.08221     -0.39008 *
+ * O              48     -0.05562     -0.06487     -0.38865 *
+ * O              49      1.65501     -1.76931      0.96848 *
+ * O              50      0.72159      2.34028      0.96965 *
+ * O              51     -2.38155     -0.55061      0.96161 *
+ * O              52     -0.17400     -0.01233     -0.78629 *
+ * O              53      0.09416     -0.13809     -0.78180 *
+ * O              54      0.07579      0.15374     -0.78137 *
+ * O              55      0.16488      0.02278      0.84126 *
+ * O              56     -0.09807      0.12879      0.83211 *
+ * O              57     -0.05824     -0.15266      0.83351 *
+ * O              58     -0.10185      0.02429      0.38313 *
+ * O              59      0.02319     -0.09934      0.38443 *
+ * O              60      0.07744      0.07775      0.38201 *
+ * O              61     -1.65722      1.76756     -1.02169 *
+ * O              62     -0.69609     -2.31843     -1.02161 *
+ * O              63      2.34362      0.55496     -1.02785 *
+ * O              64      0.08686     -0.01602     -0.39227 *
+ * O              65     -0.02498      0.07757     -0.39069 *
+ * O              66     -0.05945     -0.06479     -0.38650 *
+ * O              67      1.66367     -1.78522      0.96059 *
+ * O              68      0.70247      2.31013      0.97068 *
+ * O              69     -2.32767     -0.54709      0.97360 *
+ * O              70     -0.16848     -0.01246     -0.78307 *
+ * O              71      0.09971     -0.14286     -0.77763 *
+ * O              72      0.07416      0.14821     -0.77862 *
+ * O              73      0.16629      0.02195      0.83642 *
+ * O              74     -0.09947      0.12853      0.82966 *
+ * O              75     -0.05696     -0.15377      0.84076 *
+ * O              76     -0.09820      0.01855      0.38491 *
+ * O              77      0.02364     -0.09944      0.38671 *
+ * O              78      0.07798      0.07640      0.38375 *
+ * O              79     -1.65607      1.75763     -1.02566 *
+ * O              80     -0.68235     -2.29744     -1.02768 *
+ * O              81      2.35297      0.54866     -1.02442 *
+ * O              82      0.08721     -0.01883     -0.38493 *
+ * O              83     -0.01907      0.08136     -0.39269 *
+ * O              84     -0.05805     -0.06566     -0.38414 *
+ * O              85      1.63966     -1.75185      0.96439 *
+ * O              86      0.69725      2.29010      0.97060 *
+ * O              87     -2.37424     -0.54773      0.96405 *
+ * O              88     -0.17561     -0.01085     -0.78613 *
+ * O              89      0.09924     -0.14067     -0.78003 *
+ * O              90      0.07719      0.14924     -0.77732 *
+ * O              91      0.16476      0.02182      0.83800 *
+ * O              92     -0.10069      0.13238      0.83125 *
+ * O              93     -0.06015     -0.15272      0.83324 *
+ * O              94     -0.10095      0.02430      0.38679 *
+ * O              95      0.02661     -0.10031      0.38772 *
+ * O              96      0.07881      0.07316      0.38179 *
+ * O              97     -1.66769      1.77960     -1.02199 *
+ * O              98     -0.68528     -2.28838     -1.02459 *
+ * O              99      2.33291      0.54713     -1.02456 *
+ * O             100      0.08226     -0.01831     -0.39094 *
+ * O             101     -0.01936      0.08062     -0.38609 *
+ * O             102     -0.05820     -0.06428     -0.38701 *
+ * O             103      1.66222     -1.77540      0.96216 *
+ * O             104      0.70039      2.31059      0.96620 *
+ * O             105     -2.37497     -0.54632      0.96661 *
+ * O             106     -0.17533     -0.01311     -0.77903 *
+ * O             107      0.09357     -0.14284     -0.78077 *
+ * O             108      0.07551      0.15057     -0.78639 *
+ * O             109      0.16745      0.01986      0.83588 *
+ * O             110     -0.10046      0.12467      0.83717 *
+ * O             111     -0.05630     -0.15838      0.82886 *
+ * O             112     -0.09887      0.02286      0.37771 *
+ * O             113      0.02494     -0.09828      0.38423 *
+ * O             114      0.07528      0.07408      0.38262 *
+ * O             115     -1.65556      1.75693     -1.02997 *
+ * O             116     -0.69475     -2.30806     -1.02587 *
+ * O             117      2.33792      0.55057     -1.02723 *
+ * O             118      0.08765     -0.01847     -0.38875 *
+ * O             119     -0.02165      0.07990     -0.39214 *
+ * O             120     -0.05943     -0.06601     -0.38907 *
+ * O             121      1.65297     -1.76768      0.96352 *
+ * O             122      0.72157      2.33033      0.95716 *
+ * O             123     -2.34531     -0.54984      0.96773 *
+ * O             124     -0.17228     -0.01129     -0.78050 *
+ * O             125      0.09676     -0.14490     -0.78057 *
+ * O             126      0.07089      0.15337     -0.78177 *
+ * O             127      0.16115      0.02227      0.84185 *
+ * O             128     -0.10303      0.12375      0.83517 *
+ * O             129     -0.05810     -0.15100      0.83411 *
+ * O             130     -0.10364      0.01752      0.38543 *
+ * O             131      0.02277     -0.10447      0.38642 *
+ * O             132      0.07756      0.07049      0.38120 *
+ * O             133     -1.66560      1.77344     -1.01461 *
+ * O             134     -0.69255     -2.32101     -1.02912 *
+ * O             135      2.33280      0.55818     -1.03222 *
+ * O             136      0.08688     -0.01755     -0.39492 *
+ * O             137     -0.02433      0.08009     -0.38899 *
+ * O             138     -0.05851     -0.06502     -0.38376 *
+ * O             139      1.62402     -1.72508      0.95117 *
+ * O             140      0.71286      2.30713      0.95289 *
+ * O             141     -2.38159     -0.55339      0.96411 *
+ * O             142     -0.17286     -0.00948     -0.78728 *
+ * O             143      0.09383     -0.14417     -0.77833 *
+ * O             144      0.07752      0.15183     -0.78278 *
+ * O             145      0.16617      0.01873      0.83873 *
+ * O             146     -0.10322      0.12873      0.83002 *
+ * O             147     -0.05859     -0.15523      0.83770 *
+ * O             148     -0.10135      0.02072      0.38320 *
+ * O             149      0.01960     -0.09942      0.38902 *
+ * O             150      0.07958      0.07330      0.38554 *
+ * O             151     -1.66310      1.76724     -1.00903 *
+ * O             152     -0.67966     -2.28667     -1.02453 *
+ * O             153      2.34833      0.55169     -1.03607 *
+ * O             154      0.08071     -0.01561     -0.39013 *
+ * O             155     -0.02507      0.07975     -0.39310 *
+ * O             156     -0.06092     -0.06568     -0.38658 *
+ * O             157      1.63361     -1.74447      0.95822 *
+ * O             158      0.71478      2.32117      0.96174 *
+ * O             159     -2.38067     -0.54377      0.95644 *
+ * O             160     -0.17900     -0.01507     -0.77755 *
+ * O             161      0.09116     -0.13759     -0.78148 *
+ * O             162      0.07860      0.14787     -0.78267 *
+ * Al              1      0.00113     -0.00116     -0.02327 *
+ * Al              2      0.00082      0.00376     -0.86201 *
+ * Al              3     -0.00027     -0.00565     -1.97540 *
+ * Al              4      0.00085     -0.00077     -0.23276 *
+ * Al              5      0.00010     -0.00116     -0.08241 *
+ * Al              6      0.00120     -0.00106      0.08493 *
+ * Al              7      0.02666     -0.01106     -7.29085 *
+ * Al              8      0.00768      0.00262      7.29526 *
+ * Al              9      0.00132     -0.00117      0.02950 *
+ * Al             10      0.00071     -0.00090      0.25444 *
+ * Al             11     -0.01985      0.00162      0.86616 *
+ * Al             12     -0.00485      0.00462      1.97860 *
+ * Al             13      0.00064     -0.00112     -0.02356 *
+ * Al             14     -0.00506     -0.00691     -0.85683 *
+ * Al             15      0.00571     -0.00717     -1.97135 *
+ * Al             16      0.00090     -0.00074     -0.23312 *
+ * Al             17      0.00081     -0.00115     -0.08228 *
+ * Al             18      0.00075     -0.00072      0.08473 *
+ * Al             19     -0.01501     -0.00275     -7.29191 *
+ * Al             20      0.00207      0.01844      7.29487 *
+ * Al             21      0.00116     -0.00085      0.02983 *
+ * Al             22      0.00146     -0.00142      0.25422 *
+ * Al             23      0.00222     -0.01612      0.86314 *
+ * Al             24      0.00589      0.00442      1.97529 *
+ * Al             25      0.00096     -0.00117     -0.02313 *
+ * Al             26     -0.01771     -0.00112     -0.86572 *
+ * Al             27      0.00962     -0.00524     -1.97527 *
+ * Al             28      0.00091     -0.00048     -0.23298 *
+ * Al             29      0.00049     -0.00102     -0.08246 *
+ * Al             30      0.00142     -0.00096      0.08487 *
+ * Al             31     -0.01157      0.00366     -7.29179 *
+ * Al             32      0.01219      0.01420      7.29319 *
+ * Al             33      0.00125     -0.00087      0.02959 *
+ * Al             34      0.00107     -0.00080      0.25434 *
+ * Al             35     -0.01761     -0.01949      0.87206 *
+ * Al             36      0.00546     -0.00570      1.97151 *
+ * Al             37      0.00090     -0.00097     -0.02306 *
+ * Al             38     -0.00962     -0.00689     -0.86648 *
+ * Al             39      0.00530     -0.00109     -1.97025 *
+ * Al             40      0.00115     -0.00074     -0.23308 *
+ * Al             41      0.00084     -0.00104     -0.08221 *
+ * Al             42      0.00150     -0.00076      0.08487 *
+ * Al             43      0.00360     -0.01428     -7.29226 *
+ * Al             44      0.01179      0.01201      7.29425 *
+ * Al             45      0.00087     -0.00145      0.02973 *
+ * Al             46      0.00105     -0.00116      0.25410 *
+ * Al             47      0.00335      0.00585      0.87102 *
+ * Al             48     -0.00691     -0.00019      1.98260 *
+ * Al             49      0.00147     -0.00131     -0.02336 *
+ * Al             50     -0.00729      0.00195     -0.86273 *
+ * Al             51      0.00137     -0.00843     -1.97298 *
+ * Al             52      0.00121     -0.00075     -0.23266 *
+ * Al             53      0.00048     -0.00125     -0.08234 *
+ * Al             54      0.00105     -0.00075      0.08455 *
+ * Al             55     -0.01819      0.01410     -7.29123 *
+ * Al             56      0.01117      0.01121      7.29484 *
+ * Al             57      0.00072     -0.00124      0.02979 *
+ * Al             58      0.00120     -0.00128      0.25428 *
+ * Al             59      0.01109     -0.00610      0.85700 *
+ * Al             60      0.00802      0.00658      1.98497 *
+ * Al             61      0.00098     -0.00108     -0.02351 *
+ * Al             62     -0.01444     -0.00315     -0.85881 *
+ * Al             63      0.01034     -0.00707     -1.97405 *
+ * Al             64      0.00115     -0.00120     -0.23350 *
+ * Al             65      0.00092     -0.00098     -0.08207 *
+ * Al             66      0.00149     -0.00096      0.08491 *
+ * Al             67     -0.02505     -0.00703     -7.29133 *
+ * Al             68     -0.01102      0.01891      7.29378 *
+ * Al             69      0.00111     -0.00141      0.02981 *
+ * Al             70      0.00126     -0.00106      0.25374 *
+ * Al             71      0.01164     -0.01510      0.86577 *
+ * Al             72      0.00326      0.00486      1.97621 *
+ * Al             73      0.00092     -0.00103     -0.02349 *
+ * Al             74     -0.00178     -0.01070     -0.86212 *
+ * Al             75      0.00334     -0.00319     -1.97216 *
+ * Al             76      0.00051     -0.00085     -0.23300 *
+ * Al             77      0.00049     -0.00098     -0.08267 *
+ * Al             78      0.00088     -0.00113      0.08425 *
+ * Al             79      0.00368      0.00240     -7.29219 *
+ * Al             80     -0.00476      0.00470      7.29457 *
+ * Al             81      0.00063     -0.00123      0.02961 *
+ * Al             82      0.00092     -0.00110      0.25432 *
+ * Al             83      0.00302      0.00515      0.86503 *
+ * Al             84      0.00026     -0.00672      1.97962 *
+ * Al             85      0.00076     -0.00160     -0.02325 *
+ * Al             86     -0.01320     -0.00180     -0.86346 *
+ * Al             87      0.00720     -0.00143     -1.96932 *
+ * Al             88      0.00118     -0.00123     -0.23295 *
+ * Al             89      0.00078     -0.00101     -0.08235 *
+ * Al             90      0.00118     -0.00088      0.08455 *
+ * Al             91     -0.00684      0.04154     -7.29151 *
+ * Al             92      0.01947      0.01761      7.29427 *
+ * Al             93      0.00083     -0.00090      0.03000 *
+ * Al             94      0.00132     -0.00133      0.25410 *
+ * Al             95     -0.00069     -0.00762      0.85245 *
+ * Al             96      0.01866     -0.00239      1.98458 *
+ * Al             97      0.00045     -0.00100     -0.02321 *
+ * Al             98     -0.01307      0.00382     -0.86060 *
+ * Al             99      0.00414     -0.01155     -1.97357 *
+ * Al            100      0.00108     -0.00070     -0.23295 *
+ * Al            101      0.00069     -0.00116     -0.08206 *
+ * Al            102      0.00105     -0.00077      0.08478 *
+ * Al            103     -0.01061      0.02062     -7.29186 *
+ * Al            104     -0.00511      0.01529      7.29472 *
+ * Al            105      0.00100     -0.00090      0.02975 *
+ * Al            106      0.00102     -0.00147      0.25422 *
+ * Al            107     -0.00442     -0.01625      0.86324 *
+ * Al            108      0.01290     -0.00167      1.98003 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.60 s
+Calculation time    =    151.37 s
+Finalisation time   =      4.49 s
+Total time          =    158.46 s
+Peak Memory Use     = 1278584 kB
+  
+Overall parallel efficiency rating: Poor (42%)                                  
+  
+Data was distributed by:-
+G-vector (256-way); efficiency rating: Poor (44%)                               
+k-point (2-way); efficiency rating: Excellent (94%)                             
+  
+Parallel notes:
+1) Calculation only took 154.0 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_4smp_202109031718.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_4smp_202109031718.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:15:50 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 4-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          4
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      473.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          530.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                         2.69  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      16.32  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      25.83  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      35.31  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      47.03  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      58.42  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      71.31  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      82.60  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      93.89  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003     105.06  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     116.40  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     126.52  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.22 s
+Calculation time    =    129.54 s
+Finalisation time   =      1.63 s
+Total time          =    133.39 s
+Peak Memory Use     = 1768076 kB
+  
+Overall parallel efficiency rating: Terrible (30%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Terrible (32%)                           
+k-point (2-way); efficiency rating: Very good (89%)                             
+  
+Parallel notes:
+1) Calculation only took 131.8 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_4smp_202109031753.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_4smp_202109031753.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:51:33 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 8-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          8
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      473.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          530.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                         2.59  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      15.09  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      24.08  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      34.27  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      45.08  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      55.88  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      67.43  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      77.76  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      88.44  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003      98.81  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     109.20  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     118.90  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.18 s
+Calculation time    =    122.20 s
+Finalisation time   =      1.79 s
+Total time          =    126.16 s
+Peak Memory Use     = 1722620 kB
+  
+Overall parallel efficiency rating: Terrible (32%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Terrible (34%)                           
+k-point (2-way); efficiency rating: Excellent (91%)                             
+  
+Parallel notes:
+1) Calculation only took 124.4 s, so efficiency estimates may be inaccurate.    

--- a/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_8smp_202109031753.castep
+++ b/apps/CASTEP/al3x3/results/Sulis_OpenBLAS-0.3.12/al3x3_8nodes_1024ranks_1threads_8smp_202109031753.castep
@@ -1,0 +1,873 @@
+ +-------------------------------------------------+
+ |                                                 |
+ |      CCC   AA    SSS  TTTTT  EEEEE  PPPP        |
+ |     C     A  A  S       T    E      P   P       |
+ |     C     AAAA   SS     T    EEE    PPPP        |
+ |     C     A  A     S    T    E      P           |
+ |      CCC  A  A  SSS     T    EEEEE  P           |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ | Welcome to Academic Release CASTEP version 20.11|          
+ | Ab Initio Total Energy Program                  |
+ |                                                 |
+ | Authors:                                        |
+ | M. Segall, M. Probert, C. Pickard, P. Hasnip,   |
+ | S. Clark, K. Refson, J. R. Yates, M. Payne      |
+ |                                                 |
+ | Contributors:                                   |
+ | P. Lindan, P. Haynes, J. White, V. Milman,      |
+ | N. Govind, M. Gibson, P. Tulip, V. Cocula,      |
+ | B. Montanari, D. Quigley, M. Glover,            |
+ | L. Bernasconi, A. Perlov, M. Plummer,           |
+ | E. McNellis, J. Meyer, J. Gale, D. Jochym       |
+ | J. Aarons, B. Walker, R. Gillen, D. Jones       |
+ | T. Green, I. J. Bush, C. J. Armstrong,          |
+ | E. J. Higgins, E. L. Brown, M. S. McFly,        |
+ | J. Wilkins, B-C. Shih, P. J. P. Byrne,          |
+ | R. J. Maurer, J. C. Womack, J. Dziedzic,        |
+ | J. R. Kermode, A. Bartok-Partay                 |
+ |                                                 |
+ | Copyright (c) 2000 - 2020                       |
+ |                                                 |
+ |     Distributed under license from Cambridge    |
+ |     Enterprise for academic use only.           |
+ |                                                 |
+ | Please cite                                     |
+ |                                                 |
+ |     "First principles methods using CASTEP"     |
+ |                                                 |
+ |         Zeitschrift fuer Kristallographie       |
+ |           220(5-6) pp. 567-570 (2005)           |
+ |                                                 |
+ | S. J. Clark, M. D. Segall, C. J. Pickard,       |
+ | P. J. Hasnip, M. J. Probert, K. Refson,         |
+ | M. C. Payne                                     |
+ |                                                 |
+ |       in all publications arising from          |
+ |              your use of CASTEP                 |
+ |                                                 |
+ +-------------------------------------------------+
+ |                                                 |
+ |              http://www.castep.org              |
+ |                                                 |
+ +-------------------------------------------------+
+
+
+
+ Compiled for linux_x86_64_gfortran10 on Wed, 11 Aug 2021 16:41:27 +0100
+ from code version e772bf432+  HEAD  Sat Apr 3 17:41:32 2021 +0100
+ Compiler: GNU Fortran 10.2.0; Optimisation: fast
+ MATHLIBS: openblas (LAPACK version 3.9.0)
+ FFT Lib : fftw3 version fftw-3.3.8-sse2-avx-avx2-avx2_128
+ Fundamental constants values: CODATA 2014
+
+ Run started: Fri, 03 Sep 2021 17:51:33 +0100
+
+ Pseudo atomic calculation performed for O 2s2 2p4
+
+ Converged in 13 iterations to a total energy of -430.9847 eV
+
+ Pseudo atomic calculation performed for Al 3s2 3p1
+
+ Converged in 14 iterations to a total energy of -53.3906 eV
+ Calculation parallelised over 1024 processes.
+ Data is distributed by G-vector(512-way) and k-point(2-way)
+ G-vector communication optimised for up to 8-way SMP.
+
+ ************************************ Title ************************************
+ 3x3 sapphire surface benchmark (v1.1)
+
+ ***************************** General Parameters ******************************
+  
+ output verbosity                               : normal  (1)
+ write checkpoint data to                       : al3x3.check
+ type of calculation                            : single point energy
+ stress calculation                             : off
+ density difference calculation                 : off
+ electron localisation func (ELF) calculation   : off
+ Hirshfeld analysis                             : off
+ molecular orbital projected DOS                : off
+ deltaSCF calculation                           : off
+ unlimited duration calculation
+ timing information                             : on
+ memory usage estimate                          : on
+ write extra output files                       : on
+ write final potential to formatted file        : off
+ write final density to formatted file          : off
+ write BibTeX reference list                    : on
+ write OTFG pseudopotential files               : on
+ write electrostatic potential file             : on
+ write bands file                               : on
+ checkpoint writing                             : both castep_bin and check files
+  
+ output         length unit                     : A
+ output           mass unit                     : amu
+ output           time unit                     : ps
+ output         charge unit                     : e
+ output           spin unit                     : hbar/2
+ output         energy unit                     : eV
+ output          force unit                     : eV/A
+ output       velocity unit                     : A/ps
+ output       pressure unit                     : GPa
+ output     inv_length unit                     : 1/A
+ output      frequency unit                     : cm-1
+ output force constant unit                     : eV/A**2
+ output         volume unit                     : A**3
+ output   IR intensity unit                     : (D/A)**2/amu
+ output         dipole unit                     : D
+ output         efield unit                     : eV/A/e
+ output        entropy unit                     : J/mol/K
+ output    efield chi2 unit                     : pm/V
+  
+ wavefunctions paging                           : none
+ random number generator seed                   :          1
+ data distribution                              : optimal for this architecture
+ optimization strategy                          : maximize speed(+++)
+ num active processors in SMP node              :          8
+
+ *********************** Exchange-Correlation Parameters ***********************
+  
+ using functional                               : Perdew Wang (1991)
+ relativistic treatment                         : Koelling-Harmon
+ DFT+D: Semi-empirical dispersion correction    : off
+
+ ************************* Pseudopotential Parameters **************************
+  
+ pseudopotential representation                 : reciprocal space
+ <beta|phi> representation                      : reciprocal space
+ spin-orbit coupling                            : off
+
+ **************************** Basis Set Parameters *****************************
+  
+ plane wave basis set cut-off                   :   400.0000   eV
+ size of standard grid                          :     1.7500
+ size of   fine   gmax                          :    17.9311   1/A
+ finite basis set correction                    : none
+
+ **************************** Electronic Parameters ****************************
+  
+ number of  electrons                           :  1296.    
+ net charge of system                           :  0.000    
+ treating system as non-spin-polarized
+ number of bands                                :        768
+
+ ********************* Electronic Minimization Parameters **********************
+  
+ Method: Treating system as metallic with density mixing treatment of electrons,
+         and number of  SD  steps               :          1
+         and number of  CG  steps               :          4
+  
+ total energy / atom convergence tol.           : 0.1500E-01   eV
+ eigen-energy convergence tolerance             : 0.1000E-05   eV
+ max force / atom convergence tol.              : ignored
+ convergence tolerance window                   :          3   cycles
+ max. number of SCF cycles                      :         40
+ smearing scheme                                : Gaussian
+ smearing width                                 : 0.1000       eV
+ Fermi energy convergence tolerance             : 0.2721E-13   eV
+ periodic dipole correction                     : NONE
+
+ ************************** Density Mixing Parameters **************************
+  
+ density-mixing scheme                          : Pulay
+ max. length of mixing history                  :         20
+ charge density mixing amplitude                : 0.8000    
+ cut-off energy for mixing                      :  400.0       eV
+
+ *******************************************************************************
+  
+
+                           -------------------------------
+                                      Unit Cell
+                           -------------------------------
+        Real Lattice(A)                      Reciprocal Lattice(1/A)
+    12.3642447    -7.1385000     0.0000000        0.508173808   0.000000000   0.000000000
+     0.0000000    14.2770000     0.0000000        0.254086904   0.440091427   0.000000000
+     0.0000000     0.0000000    27.5000000        0.000000000   0.000000000   0.228479466
+
+                       Lattice parameters(A)       Cell Angles
+                    a =     14.277000          alpha =   90.000000
+                    b =     14.277000          beta  =   90.000000
+                    c =     27.500000          gamma =  120.000000
+
+                       Current cell volume =          4854.418839       A**3
+                                   density =             1.134206   AMU/A**3
+                                           =             1.883393     g/cm^3
+
+                           -------------------------------
+                                     Cell Contents
+                           -------------------------------
+                         Total number of ions in cell =  270
+                      Total number of species in cell =    2
+                        Max number of any one species =  162
+
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+            x  Element    Atom        Fractional coordinates of atoms  x
+            x            Number           u          v          w      x
+            x----------------------------------------------------------x
+            x  O            1         0.102000   0.000000   0.645700   x 
+            x  O            2         0.000000   0.102000   0.645700   x 
+            x  O            3         0.231333   0.231333   0.645700   x 
+            x  O            4         0.009111   0.222222   0.724433   x 
+            x  O            5         0.111111   0.120222   0.724433   x 
+            x  O            6         0.213111   0.324222   0.724433   x 
+            x  O            7         0.120222   0.111111   0.566967   x 
+            x  O            8         0.222222   0.009111   0.566967   x 
+            x  O            9         0.324222   0.213111   0.566967   x 
+            x  O           10         0.324222   0.111111   0.803167   x 
+            x  O           11         0.222222   0.213111   0.803167   x 
+            x  O           12         0.120222   0.009111   0.803167   x 
+            x  O           13         0.213111   0.222222   0.960633   x 
+            x  O           14         0.111111   0.324222   0.960633   x 
+            x  O           15         0.009111   0.120222   0.960633   x 
+            x  O           16         0.231333   0.000000   0.881900   x 
+            x  O           17         0.000000   0.231333   0.881900   x 
+            x  O           18         0.102000   0.102000   0.881900   x 
+            x  O           19         0.102000   0.333333   0.645700   x 
+            x  O           20         0.000000   0.435333   0.645700   x 
+            x  O           21         0.231333   0.564667   0.645700   x 
+            x  O           22         0.009111   0.555556   0.724433   x 
+            x  O           23         0.111111   0.453556   0.724433   x 
+            x  O           24         0.213111   0.657556   0.724433   x 
+            x  O           25         0.120222   0.444444   0.566967   x 
+            x  O           26         0.222222   0.342444   0.566967   x 
+            x  O           27         0.324222   0.546444   0.566967   x 
+            x  O           28         0.324222   0.444444   0.803167   x 
+            x  O           29         0.222222   0.546444   0.803167   x 
+            x  O           30         0.120222   0.342444   0.803167   x 
+            x  O           31         0.213111   0.555556   0.960633   x 
+            x  O           32         0.111111   0.657556   0.960633   x 
+            x  O           33         0.009111   0.453556   0.960633   x 
+            x  O           34         0.231333   0.333333   0.881900   x 
+            x  O           35         0.000000   0.564667   0.881900   x 
+            x  O           36         0.102000   0.435333   0.881900   x 
+            x  O           37         0.102000   0.666667   0.645700   x 
+            x  O           38         0.000000   0.768667   0.645700   x 
+            x  O           39         0.231333   0.898000   0.645700   x 
+            x  O           40         0.009111   0.888889   0.724433   x 
+            x  O           41         0.111111   0.786889   0.724433   x 
+            x  O           42         0.213111   0.990889   0.724433   x 
+            x  O           43         0.120222   0.777778   0.566967   x 
+            x  O           44         0.222222   0.675778   0.566967   x 
+            x  O           45         0.324222   0.879778   0.566967   x 
+            x  O           46         0.324222   0.777778   0.803167   x 
+            x  O           47         0.222222   0.879778   0.803167   x 
+            x  O           48         0.120222   0.675778   0.803167   x 
+            x  O           49         0.213111   0.888889   0.960633   x 
+            x  O           50         0.111111   0.990889   0.960633   x 
+            x  O           51         0.009111   0.786889   0.960633   x 
+            x  O           52         0.231333   0.666667   0.881900   x 
+            x  O           53         0.000000   0.898000   0.881900   x 
+            x  O           54         0.102000   0.768667   0.881900   x 
+            x  O           55         0.435333   0.000000   0.645700   x 
+            x  O           56         0.333333   0.102000   0.645700   x 
+            x  O           57         0.564667   0.231333   0.645700   x 
+            x  O           58         0.342444   0.222222   0.724433   x 
+            x  O           59         0.444444   0.120222   0.724433   x 
+            x  O           60         0.546444   0.324222   0.724433   x 
+            x  O           61         0.453556   0.111111   0.566967   x 
+            x  O           62         0.555556   0.009111   0.566967   x 
+            x  O           63         0.657556   0.213111   0.566967   x 
+            x  O           64         0.657556   0.111111   0.803167   x 
+            x  O           65         0.555556   0.213111   0.803167   x 
+            x  O           66         0.453556   0.009111   0.803167   x 
+            x  O           67         0.546444   0.222222   0.960633   x 
+            x  O           68         0.444444   0.324222   0.960633   x 
+            x  O           69         0.342444   0.120222   0.960633   x 
+            x  O           70         0.564667   0.000000   0.881900   x 
+            x  O           71         0.333333   0.231333   0.881900   x 
+            x  O           72         0.435333   0.102000   0.881900   x 
+            x  O           73         0.435333   0.333333   0.645700   x 
+            x  O           74         0.333333   0.435333   0.645700   x 
+            x  O           75         0.564667   0.564667   0.645700   x 
+            x  O           76         0.342444   0.555556   0.724433   x 
+            x  O           77         0.444444   0.453556   0.724433   x 
+            x  O           78         0.546444   0.657556   0.724433   x 
+            x  O           79         0.453556   0.444444   0.566967   x 
+            x  O           80         0.555556   0.342444   0.566967   x 
+            x  O           81         0.657556   0.546444   0.566967   x 
+            x  O           82         0.657556   0.444444   0.803167   x 
+            x  O           83         0.555556   0.546444   0.803167   x 
+            x  O           84         0.453556   0.342444   0.803167   x 
+            x  O           85         0.546444   0.555556   0.960633   x 
+            x  O           86         0.444444   0.657556   0.960633   x 
+            x  O           87         0.342444   0.453556   0.960633   x 
+            x  O           88         0.564667   0.333333   0.881900   x 
+            x  O           89         0.333333   0.564667   0.881900   x 
+            x  O           90         0.435333   0.435333   0.881900   x 
+            x  O           91         0.435333   0.666667   0.645700   x 
+            x  O           92         0.333333   0.768667   0.645700   x 
+            x  O           93         0.564667   0.898000   0.645700   x 
+            x  O           94         0.342444   0.888889   0.724433   x 
+            x  O           95         0.444444   0.786889   0.724433   x 
+            x  O           96         0.546444   0.990889   0.724433   x 
+            x  O           97         0.453556   0.777778   0.566967   x 
+            x  O           98         0.555556   0.675778   0.566967   x 
+            x  O           99         0.657556   0.879778   0.566967   x 
+            x  O          100         0.657556   0.777778   0.803167   x 
+            x  O          101         0.555556   0.879778   0.803167   x 
+            x  O          102         0.453556   0.675778   0.803167   x 
+            x  O          103         0.546444   0.888889   0.960633   x 
+            x  O          104         0.444444   0.990889   0.960633   x 
+            x  O          105         0.342444   0.786889   0.960633   x 
+            x  O          106         0.564667   0.666667   0.881900   x 
+            x  O          107         0.333333   0.898000   0.881900   x 
+            x  O          108         0.435333   0.768667   0.881900   x 
+            x  O          109         0.768667   0.000000   0.645700   x 
+            x  O          110         0.666667   0.102000   0.645700   x 
+            x  O          111         0.898000   0.231333   0.645700   x 
+            x  O          112         0.675778   0.222222   0.724433   x 
+            x  O          113         0.777778   0.120222   0.724433   x 
+            x  O          114         0.879778   0.324222   0.724433   x 
+            x  O          115         0.786889   0.111111   0.566967   x 
+            x  O          116         0.888889   0.009111   0.566967   x 
+            x  O          117         0.990889   0.213111   0.566967   x 
+            x  O          118         0.990889   0.111111   0.803167   x 
+            x  O          119         0.888889   0.213111   0.803167   x 
+            x  O          120         0.786889   0.009111   0.803167   x 
+            x  O          121         0.879778   0.222222   0.960633   x 
+            x  O          122         0.777778   0.324222   0.960633   x 
+            x  O          123         0.675778   0.120222   0.960633   x 
+            x  O          124         0.898000   0.000000   0.881900   x 
+            x  O          125         0.666667   0.231333   0.881900   x 
+            x  O          126         0.768667   0.102000   0.881900   x 
+            x  O          127         0.768667   0.333333   0.645700   x 
+            x  O          128         0.666667   0.435333   0.645700   x 
+            x  O          129         0.898000   0.564667   0.645700   x 
+            x  O          130         0.675778   0.555556   0.724433   x 
+            x  O          131         0.777778   0.453556   0.724433   x 
+            x  O          132         0.879778   0.657556   0.724433   x 
+            x  O          133         0.786889   0.444444   0.566967   x 
+            x  O          134         0.888889   0.342444   0.566967   x 
+            x  O          135         0.990889   0.546444   0.566967   x 
+            x  O          136         0.990889   0.444444   0.803167   x 
+            x  O          137         0.888889   0.546444   0.803167   x 
+            x  O          138         0.786889   0.342444   0.803167   x 
+            x  O          139         0.879778   0.555556   0.960633   x 
+            x  O          140         0.777778   0.657556   0.960633   x 
+            x  O          141         0.675778   0.453556   0.960633   x 
+            x  O          142         0.898000   0.333333   0.881900   x 
+            x  O          143         0.666667   0.564667   0.881900   x 
+            x  O          144         0.768667   0.435333   0.881900   x 
+            x  O          145         0.768667   0.666667   0.645700   x 
+            x  O          146         0.666667   0.768667   0.645700   x 
+            x  O          147         0.898000   0.898000   0.645700   x 
+            x  O          148         0.675778   0.888889   0.724433   x 
+            x  O          149         0.777778   0.786889   0.724433   x 
+            x  O          150         0.879778   0.990889   0.724433   x 
+            x  O          151         0.786889   0.777778   0.566967   x 
+            x  O          152         0.888889   0.675778   0.566967   x 
+            x  O          153         0.990889   0.879778   0.566967   x 
+            x  O          154         0.990889   0.777778   0.803167   x 
+            x  O          155         0.888889   0.879778   0.803167   x 
+            x  O          156         0.786889   0.675778   0.803167   x 
+            x  O          157         0.879778   0.888889   0.960633   x 
+            x  O          158         0.777778   0.990889   0.960633   x 
+            x  O          159         0.675778   0.786889   0.960633   x 
+            x  O          160         0.898000   0.666667   0.881900   x 
+            x  O          161         0.666667   0.898000   0.881900   x 
+            x  O          162         0.768667   0.768667   0.881900   x 
+            x  Al           1         0.000000   0.000000   0.693885   x 
+            x  Al           2         0.000000   0.000000   0.597515   x 
+            x  Al           3         0.222222   0.111111   0.615151   x 
+            x  Al           4         0.111111   0.222222   0.676249   x 
+            x  Al           5         0.222222   0.111111   0.754982   x 
+            x  Al           6         0.111111   0.222222   0.772618   x 
+            x  Al           7         0.222222   0.111111   0.991182   x 
+            x  Al           8         0.111111   0.222222   0.536418   x 
+            x  Al           9         0.000000   0.000000   0.833715   x 
+            x  Al          10         0.222222   0.111111   0.851351   x 
+            x  Al          11         0.000000   0.000000   0.930085   x 
+            x  Al          12         0.111111   0.222222   0.912449   x 
+            x  Al          13         0.000000   0.333333   0.693885   x 
+            x  Al          14         0.000000   0.333333   0.597515   x 
+            x  Al          15         0.222222   0.444444   0.615151   x 
+            x  Al          16         0.111111   0.555556   0.676249   x 
+            x  Al          17         0.222222   0.444444   0.754982   x 
+            x  Al          18         0.111111   0.555556   0.772618   x 
+            x  Al          19         0.222222   0.444444   0.991182   x 
+            x  Al          20         0.111111   0.555556   0.536418   x 
+            x  Al          21         0.000000   0.333333   0.833715   x 
+            x  Al          22         0.222222   0.444444   0.851351   x 
+            x  Al          23         0.000000   0.333333   0.930085   x 
+            x  Al          24         0.111111   0.555556   0.912449   x 
+            x  Al          25         0.000000   0.666667   0.693885   x 
+            x  Al          26         0.000000   0.666667   0.597515   x 
+            x  Al          27         0.222222   0.777778   0.615151   x 
+            x  Al          28         0.111111   0.888889   0.676249   x 
+            x  Al          29         0.222222   0.777778   0.754982   x 
+            x  Al          30         0.111111   0.888889   0.772618   x 
+            x  Al          31         0.222222   0.777778   0.991182   x 
+            x  Al          32         0.111111   0.888889   0.536418   x 
+            x  Al          33         0.000000   0.666667   0.833715   x 
+            x  Al          34         0.222222   0.777778   0.851351   x 
+            x  Al          35         0.000000   0.666667   0.930085   x 
+            x  Al          36         0.111111   0.888889   0.912449   x 
+            x  Al          37         0.333333   0.000000   0.693885   x 
+            x  Al          38         0.333333   0.000000   0.597515   x 
+            x  Al          39         0.555556   0.111111   0.615151   x 
+            x  Al          40         0.444444   0.222222   0.676249   x 
+            x  Al          41         0.555556   0.111111   0.754982   x 
+            x  Al          42         0.444444   0.222222   0.772618   x 
+            x  Al          43         0.555556   0.111111   0.991182   x 
+            x  Al          44         0.444444   0.222222   0.536418   x 
+            x  Al          45         0.333333   0.000000   0.833715   x 
+            x  Al          46         0.555556   0.111111   0.851351   x 
+            x  Al          47         0.333333   0.000000   0.930085   x 
+            x  Al          48         0.444444   0.222222   0.912449   x 
+            x  Al          49         0.333333   0.333333   0.693885   x 
+            x  Al          50         0.333333   0.333333   0.597515   x 
+            x  Al          51         0.555556   0.444444   0.615151   x 
+            x  Al          52         0.444444   0.555556   0.676249   x 
+            x  Al          53         0.555556   0.444444   0.754982   x 
+            x  Al          54         0.444444   0.555556   0.772618   x 
+            x  Al          55         0.555556   0.444444   0.991182   x 
+            x  Al          56         0.444444   0.555556   0.536418   x 
+            x  Al          57         0.333333   0.333333   0.833715   x 
+            x  Al          58         0.555556   0.444444   0.851351   x 
+            x  Al          59         0.333333   0.333333   0.930085   x 
+            x  Al          60         0.444444   0.555556   0.912449   x 
+            x  Al          61         0.333333   0.666667   0.693885   x 
+            x  Al          62         0.333333   0.666667   0.597515   x 
+            x  Al          63         0.555556   0.777778   0.615151   x 
+            x  Al          64         0.444444   0.888889   0.676249   x 
+            x  Al          65         0.555556   0.777778   0.754982   x 
+            x  Al          66         0.444444   0.888889   0.772618   x 
+            x  Al          67         0.555556   0.777778   0.991182   x 
+            x  Al          68         0.444444   0.888889   0.536418   x 
+            x  Al          69         0.333333   0.666667   0.833715   x 
+            x  Al          70         0.555556   0.777778   0.851351   x 
+            x  Al          71         0.333333   0.666667   0.930085   x 
+            x  Al          72         0.444444   0.888889   0.912449   x 
+            x  Al          73         0.666667   0.000000   0.693885   x 
+            x  Al          74         0.666667   0.000000   0.597515   x 
+            x  Al          75         0.888889   0.111111   0.615151   x 
+            x  Al          76         0.777778   0.222222   0.676249   x 
+            x  Al          77         0.888889   0.111111   0.754982   x 
+            x  Al          78         0.777778   0.222222   0.772618   x 
+            x  Al          79         0.888889   0.111111   0.991182   x 
+            x  Al          80         0.777778   0.222222   0.536418   x 
+            x  Al          81         0.666667   0.000000   0.833715   x 
+            x  Al          82         0.888889   0.111111   0.851351   x 
+            x  Al          83         0.666667   0.000000   0.930085   x 
+            x  Al          84         0.777778   0.222222   0.912449   x 
+            x  Al          85         0.666667   0.333333   0.693885   x 
+            x  Al          86         0.666667   0.333333   0.597515   x 
+            x  Al          87         0.888889   0.444444   0.615151   x 
+            x  Al          88         0.777778   0.555556   0.676249   x 
+            x  Al          89         0.888889   0.444444   0.754982   x 
+            x  Al          90         0.777778   0.555556   0.772618   x 
+            x  Al          91         0.888889   0.444444   0.991182   x 
+            x  Al          92         0.777778   0.555556   0.536418   x 
+            x  Al          93         0.666667   0.333333   0.833715   x 
+            x  Al          94         0.888889   0.444444   0.851351   x 
+            x  Al          95         0.666667   0.333333   0.930085   x 
+            x  Al          96         0.777778   0.555556   0.912449   x 
+            x  Al          97         0.666667   0.666667   0.693885   x 
+            x  Al          98         0.666667   0.666667   0.597515   x 
+            x  Al          99         0.888889   0.777778   0.615151   x 
+            x  Al         100         0.777778   0.888889   0.676249   x 
+            x  Al         101         0.888889   0.777778   0.754982   x 
+            x  Al         102         0.777778   0.888889   0.772618   x 
+            x  Al         103         0.888889   0.777778   0.991182   x 
+            x  Al         104         0.777778   0.888889   0.536418   x 
+            x  Al         105         0.666667   0.666667   0.833715   x 
+            x  Al         106         0.888889   0.777778   0.851351   x 
+            x  Al         107         0.666667   0.666667   0.930085   x 
+            x  Al         108         0.777778   0.888889   0.912449   x 
+            xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+                         No user defined ionic velocities
+
+                           -------------------------------
+                                   Details of Species
+                           -------------------------------
+
+                               Mass of species in AMU
+                                    O   15.9994000
+                                    Al   26.9815400
+
+                          Electric Quadrupole Moment (Barn)
+                                    O   -0.0255800 Isotope 17
+                                    Al    0.1466000 Isotope 27
+
+                          Files used for pseudopotentials:
+                                    O O_00.usp
+                                    Al Al_00.usp
+
+                           -------------------------------
+                              k-Points For BZ Sampling
+                           -------------------------------
+                       MP grid size for SCF calculation is  2  2  1
+                            with an offset of   0.000  0.000  0.000
+                       Number of kpoints used =             2
+
+                           -------------------------------
+                               Symmetry and Constraints
+                           -------------------------------
+
+                      Cell is a supercell containing 9 primitive cells
+                      Maximum deviation from symmetry =  0.00000         ANG
+
+                      Number of symmetry operations   =           1
+                      Number of ionic constraints     =           3
+                      Point group of crystal =     1: C1, 1, 1
+                      Space group of crystal =   147: P-3, -P 3
+
+             Set iprint > 1 for details on symmetry rotations/translations
+
+                         Centre of mass is constrained
+             Set iprint > 1 for details of linear ionic constraints
+
+                         Number of cell constraints= 0
+                         Cell constraints are:  1 2 3 4 5 6
+
+                         External pressure/stress (GPa)
+                          0.00000   0.00000   0.00000
+                                    0.00000   0.00000
+                                              0.00000
+  
++---------------- MEMORY AND SCRATCH DISK ESTIMATES PER PROCESS --------------+
+|                                                     Memory          Disk    |
+| Baseline code, static data and system overhead      473.0 MB         0.0 MB |
+| BLAS internal memory storage                          0.0 MB         0.0 MB |
+| Model and support data                               38.6 MB         0.0 MB |
+| Electronic energy minimisation requirements          18.4 MB         0.0 MB |
+| Force calculation requirements                        0.5 MB         0.0 MB |
+|                                               ----------------------------- |
+| Approx. total storage required per process          530.0 MB         0.0 MB |
+|                                                                             |
+| Requirements will fluctuate during execution and may exceed these estimates |
++-----------------------------------------------------------------------------+
+Calculating total energy with cut-off of  400.000 eV.
+------------------------------------------------------------------------ <-- SCF
+SCF loop      Energy           Fermi           Energy gain       Timer   <-- SCF
+                               energy          per atom          (sec)   <-- SCF
+------------------------------------------------------------------------ <-- SCF
+Initial  -5.94034950E+004  0.00000000E+000                         2.59  <-- SCF
+      1  -7.23843258E+004  4.05090297E+000   4.80771512E+001      15.09  <-- SCF
+      2  -7.78239155E+004  1.91700692E+000   2.01466286E+001      24.08  <-- SCF
+      3  -7.79864464E+004  1.80185861E+000   6.01966524E-001      34.27  <-- SCF
+      4  -7.78412315E+004  1.95889672E+000  -5.37833311E-001      45.08  <-- SCF
+      5  -7.77211163E+004  1.34881957E+000  -4.44870941E-001      55.88  <-- SCF
+      6  -7.77152220E+004  1.12208948E+000  -2.18307261E-002      67.43  <-- SCF
+      7  -7.77129490E+004  1.05285462E+000  -8.41857003E-003      77.76  <-- SCF
+      8  -7.77104518E+004  1.02760969E+000  -9.24871446E-003      88.44  <-- SCF
+      9  -7.77084306E+004  9.96466894E-001  -7.48590490E-003      98.81  <-- SCF
+     10  -7.77059728E+004  1.11180141E+000  -9.10298513E-003     109.20  <-- SCF
+     11  -7.77052095E+004  1.16233207E+000  -2.82709138E-003     118.90  <-- SCF
+------------------------------------------------------------------------ <-- SCF
+ 
+Final energy, E             =  -77705.20951832     eV
+Final free energy (E-TS)    =  -77705.20951832     eV
+(energies not corrected for finite basis set)
+ 
+NB est. 0K energy (E-0.5TS)      =  -77705.20951832     eV
+ 
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+
+ ************************** Forces **************************
+ *                                                          *
+ *               Cartesian components (eV/A)                *
+ * -------------------------------------------------------- *
+ *                         x            y            z      *
+ *                                                          *
+ * O               1      0.16860      0.02784      0.84522 *
+ * O               2     -0.10063      0.12395      0.84513 *
+ * O               3     -0.06001     -0.15392      0.84561 *
+ * O               4     -0.10474      0.02296      0.38614 *
+ * O               5      0.01579     -0.09478      0.39244 *
+ * O               6      0.07725      0.07736      0.38345 *
+ * O               7     -1.65678      1.75618     -1.00855 *
+ * O               8     -0.68049     -2.27970     -1.01793 *
+ * O               9      2.33100      0.55381     -1.02615 *
+ * O              10      0.08395     -0.01410     -0.39341 *
+ * O              11     -0.02521      0.07689     -0.39782 *
+ * O              12     -0.05999     -0.06369     -0.39366 *
+ * O              13      1.66404     -1.79226      0.94593 *
+ * O              14      0.71665      2.34282      0.95488 *
+ * O              15     -2.36287     -0.54113      0.96472 *
+ * O              16     -0.17048     -0.01077     -0.79259 *
+ * O              17      0.09245     -0.14474     -0.79445 *
+ * O              18      0.07637      0.14765     -0.78874 *
+ * O              19      0.16055      0.02098      0.83957 *
+ * O              20     -0.10150      0.12878      0.83958 *
+ * O              21     -0.06135     -0.15299      0.84057 *
+ * O              22     -0.10473      0.02508      0.39142 *
+ * O              23      0.02432     -0.09893      0.39368 *
+ * O              24      0.07692      0.07693      0.38843 *
+ * O              25     -1.65328      1.75612     -1.02297 *
+ * O              26     -0.69435     -2.31804     -1.01986 *
+ * O              27      2.35132      0.55657     -1.02794 *
+ * O              28      0.08090     -0.01352     -0.39635 *
+ * O              29     -0.02336      0.08639     -0.39309 *
+ * O              30     -0.05709     -0.06103     -0.39577 *
+ * O              31      1.63887     -1.75916      0.95663 *
+ * O              32      0.71057      2.32618      0.96325 *
+ * O              33     -2.34628     -0.54359      0.96538 *
+ * O              34     -0.17618     -0.01018     -0.79986 *
+ * O              35      0.09634     -0.14180     -0.79004 *
+ * O              36      0.07580      0.15420     -0.79149 *
+ * O              37      0.16821      0.02090      0.84512 *
+ * O              38     -0.10297      0.11990      0.84276 *
+ * O              39     -0.06207     -0.14591      0.84302 *
+ * O              40     -0.10312      0.03038      0.38901 *
+ * O              41      0.02537     -0.10045      0.39030 *
+ * O              42      0.07874      0.07494      0.38548 *
+ * O              43     -1.64157      1.73266     -1.02200 *
+ * O              44     -0.68995     -2.30079     -1.02266 *
+ * O              45      2.35318      0.56093     -1.02343 *
+ * O              46      0.08395     -0.01286     -0.39049 *
+ * O              47     -0.02569      0.07845     -0.39873 *
+ * O              48     -0.05749     -0.06403     -0.39402 *
+ * O              49      1.66750     -1.80118      0.94928 *
+ * O              50      0.69300      2.28568      0.96923 *
+ * O              51     -2.35461     -0.53986      0.96854 *
+ * O              52     -0.17296     -0.01709     -0.79065 *
+ * O              53      0.09776     -0.14237     -0.78214 *
+ * O              54      0.07308      0.14867     -0.79267 *
+ * O              55      0.16594      0.02719      0.84816 *
+ * O              56     -0.10113      0.12769      0.83552 *
+ * O              57     -0.05557     -0.15287      0.84593 *
+ * O              58     -0.10898      0.02577      0.38818 *
+ * O              59      0.02377     -0.09775      0.39246 *
+ * O              60      0.07619      0.07172      0.39113 *
+ * O              61     -1.67381      1.77770     -1.01093 *
+ * O              62     -0.69454     -2.32891     -1.02583 *
+ * O              63      2.32687      0.54808     -1.02919 *
+ * O              64      0.08298     -0.01702     -0.39386 *
+ * O              65     -0.02462      0.08183     -0.39554 *
+ * O              66     -0.05990     -0.06186     -0.39142 *
+ * O              67      1.66758     -1.80124      0.94783 *
+ * O              68      0.70491      2.31163      0.96885 *
+ * O              69     -2.34724     -0.55136      0.95990 *
+ * O              70     -0.17119     -0.00664     -0.78841 *
+ * O              71      0.09466     -0.13715     -0.78638 *
+ * O              72      0.06804      0.15209     -0.78530 *
+ * O              73      0.16561      0.01948      0.84737 *
+ * O              74     -0.10358      0.12574      0.84787 *
+ * O              75     -0.06425     -0.14492      0.84709 *
+ * O              76     -0.10401      0.02632      0.39240 *
+ * O              77      0.01725     -0.10317      0.39121 *
+ * O              78      0.07634      0.07455      0.39102 *
+ * O              79     -1.68019      1.77750     -1.01891 *
+ * O              80     -0.68603     -2.29826     -1.02203 *
+ * O              81      2.36417      0.55193     -1.03132 *
+ * O              82      0.08568     -0.02042     -0.39293 *
+ * O              83     -0.02392      0.08353     -0.39559 *
+ * O              84     -0.05965     -0.05789     -0.39572 *
+ * O              85      1.65819     -1.78371      0.95708 *
+ * O              86      0.71128      2.33191      0.96174 *
+ * O              87     -2.35338     -0.54886      0.96411 *
+ * O              88     -0.17543     -0.00724     -0.79944 *
+ * O              89      0.09431     -0.14031     -0.79004 *
+ * O              90      0.07352      0.14908     -0.79368 *
+ * O              91      0.16245      0.02237      0.83930 *
+ * O              92     -0.10126      0.12596      0.83784 *
+ * O              93     -0.06350     -0.15646      0.83682 *
+ * O              94     -0.10152      0.02592      0.38840 *
+ * O              95      0.02717     -0.10105      0.38421 *
+ * O              96      0.08020      0.07165      0.38923 *
+ * O              97     -1.65655      1.75894     -1.01982 *
+ * O              98     -0.68169     -2.28832     -1.02496 *
+ * O              99      2.31620      0.55114     -1.02171 *
+ * O             100      0.08323     -0.01258     -0.39423 *
+ * O             101     -0.02171      0.07948     -0.39429 *
+ * O             102     -0.05784     -0.05897     -0.39486 *
+ * O             103      1.65366     -1.77471      0.95664 *
+ * O             104      0.69302      2.29536      0.96443 *
+ * O             105     -2.33785     -0.54194      0.97297 *
+ * O             106     -0.16845     -0.01294     -0.79316 *
+ * O             107      0.09760     -0.14464     -0.78977 *
+ * O             108      0.07150      0.15400     -0.79096 *
+ * O             109      0.16348      0.02138      0.85137 *
+ * O             110     -0.09903      0.13190      0.84498 *
+ * O             111     -0.05973     -0.14805      0.84296 *
+ * O             112     -0.10562      0.02267      0.38880 *
+ * O             113      0.02027     -0.09863      0.39116 *
+ * O             114      0.08274      0.07751      0.38929 *
+ * O             115     -1.67108      1.78409     -1.00419 *
+ * O             116     -0.68417     -2.30434     -1.01882 *
+ * O             117      2.33665      0.55580     -1.02914 *
+ * O             118      0.07965     -0.01515     -0.39142 *
+ * O             119     -0.02101      0.08196     -0.39789 *
+ * O             120     -0.05963     -0.06279     -0.39599 *
+ * O             121      1.65047     -1.77607      0.94984 *
+ * O             122      0.69768      2.29180      0.96631 *
+ * O             123     -2.34895     -0.54371      0.96786 *
+ * O             124     -0.17107     -0.00714     -0.79378 *
+ * O             125      0.10015     -0.13785     -0.79013 *
+ * O             126      0.06907      0.14669     -0.79429 *
+ * O             127      0.15962      0.02208      0.84315 *
+ * O             128     -0.10507      0.12587      0.84531 *
+ * O             129     -0.05903     -0.14636      0.84244 *
+ * O             130     -0.10451      0.02312      0.38797 *
+ * O             131      0.02564     -0.09348      0.38681 *
+ * O             132      0.07608      0.07240      0.38467 *
+ * O             133     -1.66343      1.76449     -1.02018 *
+ * O             134     -0.69020     -2.30047     -1.02111 *
+ * O             135      2.36394      0.55989     -1.01531 *
+ * O             136      0.08363     -0.02219     -0.39342 *
+ * O             137     -0.02158      0.07815     -0.39651 *
+ * O             138     -0.05903     -0.06536     -0.39273 *
+ * O             139      1.66808     -1.79095      0.94515 *
+ * O             140      0.70028      2.30297      0.96604 *
+ * O             141     -2.36625     -0.54695      0.96859 *
+ * O             142     -0.17556     -0.01067     -0.79071 *
+ * O             143      0.09250     -0.14350     -0.78423 *
+ * O             144      0.07413      0.14580     -0.78793 *
+ * O             145      0.16092      0.02057      0.84252 *
+ * O             146     -0.10310      0.13023      0.83678 *
+ * O             147     -0.05684     -0.15043      0.85003 *
+ * O             148     -0.09867      0.02531      0.38551 *
+ * O             149      0.01870     -0.09717      0.39440 *
+ * O             150      0.07386      0.07600      0.38461 *
+ * O             151     -1.66059      1.75745     -1.01494 *
+ * O             152     -0.69759     -2.30429     -1.02689 *
+ * O             153      2.38206      0.56152     -1.01181 *
+ * O             154      0.08323     -0.01770     -0.39210 *
+ * O             155     -0.02172      0.07964     -0.39420 *
+ * O             156     -0.06307     -0.06642     -0.39330 *
+ * O             157      1.66886     -1.79649      0.94695 *
+ * O             158      0.70455      2.32331      0.96216 *
+ * O             159     -2.34716     -0.54201      0.96639 *
+ * O             160     -0.17047     -0.00954     -0.79294 *
+ * O             161      0.09064     -0.14473     -0.78508 *
+ * O             162      0.07181      0.15089     -0.79049 *
+ * Al              1     -0.00036     -0.00036     -0.01588 *
+ * Al              2     -0.00659      0.01586     -0.85270 *
+ * Al              3      0.00410     -0.00750     -1.97668 *
+ * Al              4     -0.00036      0.00019     -0.22619 *
+ * Al              5     -0.00090     -0.00000     -0.08306 *
+ * Al              6     -0.00019     -0.00002      0.08543 *
+ * Al              7     -0.00554     -0.01780     -7.29170 *
+ * Al              8     -0.00668      0.00543      7.29201 *
+ * Al              9     -0.00057      0.00003      0.02216 *
+ * Al             10     -0.00055      0.00010      0.24670 *
+ * Al             11      0.01934     -0.00083      0.85947 *
+ * Al             12     -0.00376     -0.00204      1.96995 *
+ * Al             13     -0.00113     -0.00023     -0.01581 *
+ * Al             14     -0.00251      0.00097     -0.86384 *
+ * Al             15     -0.00354      0.00046     -1.96792 *
+ * Al             16     -0.00045      0.00038     -0.22641 *
+ * Al             17     -0.00099     -0.00031     -0.08321 *
+ * Al             18     -0.00041      0.00041      0.08549 *
+ * Al             19      0.00911      0.01145     -7.29056 *
+ * Al             20      0.01546     -0.00451      7.29202 *
+ * Al             21     -0.00055     -0.00014      0.02168 *
+ * Al             22     -0.00053     -0.00029      0.24695 *
+ * Al             23     -0.00519      0.00739      0.85757 *
+ * Al             24      0.00026     -0.00322      1.97863 *
+ * Al             25     -0.00042     -0.00025     -0.01555 *
+ * Al             26      0.00314      0.01431     -0.86042 *
+ * Al             27     -0.00663     -0.00310     -1.97357 *
+ * Al             28     -0.00076      0.00055     -0.22586 *
+ * Al             29     -0.00123      0.00015     -0.08327 *
+ * Al             30     -0.00010     -0.00033      0.08529 *
+ * Al             31      0.01036     -0.01716     -7.28812 *
+ * Al             32      0.03209     -0.00770      7.29232 *
+ * Al             33     -0.00018     -0.00046      0.02205 *
+ * Al             34     -0.00062      0.00013      0.24689 *
+ * Al             35      0.00468      0.00922      0.85759 *
+ * Al             36     -0.00982      0.00856      1.97702 *
+ * Al             37     -0.00027     -0.00015     -0.01616 *
+ * Al             38     -0.01879      0.00918     -0.85824 *
+ * Al             39      0.00790      0.00216     -1.96663 *
+ * Al             40     -0.00055     -0.00012     -0.22620 *
+ * Al             41     -0.00064     -0.00035     -0.08350 *
+ * Al             42     -0.00042     -0.00001      0.08521 *
+ * Al             43     -0.00253     -0.02462     -7.28902 *
+ * Al             44      0.00122      0.02069      7.29257 *
+ * Al             45     -0.00066     -0.00036      0.02155 *
+ * Al             46     -0.00070     -0.00002      0.24700 *
+ * Al             47      0.01818      0.00624      0.86052 *
+ * Al             48     -0.00994      0.00404      1.97369 *
+ * Al             49     -0.00088      0.00008     -0.01618 *
+ * Al             50     -0.01002     -0.01161     -0.85477 *
+ * Al             51      0.00257     -0.00974     -1.96455 *
+ * Al             52     -0.00065     -0.00026     -0.22682 *
+ * Al             53     -0.00079     -0.00057     -0.08346 *
+ * Al             54     -0.00034      0.00016      0.08540 *
+ * Al             55     -0.00427     -0.00596     -7.29027 *
+ * Al             56      0.01409      0.02049      7.29143 *
+ * Al             57     -0.00048      0.00001      0.02158 *
+ * Al             58     -0.00055     -0.00012      0.24738 *
+ * Al             59      0.00672      0.00357      0.85988 *
+ * Al             60     -0.00368     -0.00341      1.97193 *
+ * Al             61     -0.00061      0.00004     -0.01604 *
+ * Al             62     -0.00590      0.00646     -0.85776 *
+ * Al             63      0.00473     -0.00334     -1.97867 *
+ * Al             64     -0.00070      0.00027     -0.22647 *
+ * Al             65     -0.00112      0.00021     -0.08324 *
+ * Al             66     -0.00023     -0.00042      0.08516 *
+ * Al             67      0.01439      0.00029     -7.28938 *
+ * Al             68     -0.00001     -0.00369      7.29030 *
+ * Al             69     -0.00031      0.00027      0.02201 *
+ * Al             70     -0.00056     -0.00028      0.24698 *
+ * Al             71     -0.01063      0.00723      0.86244 *
+ * Al             72     -0.00452      0.00361      1.98203 *
+ * Al             73     -0.00067      0.00001     -0.01603 *
+ * Al             74     -0.00957     -0.01835     -0.85377 *
+ * Al             75      0.00823     -0.00581     -1.96711 *
+ * Al             76     -0.00027      0.00010     -0.22654 *
+ * Al             77     -0.00075     -0.00035     -0.08293 *
+ * Al             78     -0.00037      0.00021      0.08512 *
+ * Al             79     -0.00118     -0.00205     -7.29011 *
+ * Al             80     -0.00561      0.02698      7.29214 *
+ * Al             81     -0.00023     -0.00019      0.02199 *
+ * Al             82     -0.00073     -0.00037      0.24706 *
+ * Al             83      0.00138      0.00487      0.86217 *
+ * Al             84     -0.00372      0.00477      1.98207 *
+ * Al             85     -0.00089     -0.00011     -0.01579 *
+ * Al             86     -0.01033     -0.00477     -0.86398 *
+ * Al             87     -0.00321     -0.00680     -1.96668 *
+ * Al             88     -0.00065     -0.00013     -0.22671 *
+ * Al             89     -0.00116     -0.00036     -0.08348 *
+ * Al             90     -0.00045      0.00006      0.08539 *
+ * Al             91     -0.00722     -0.01810     -7.29020 *
+ * Al             92      0.01279      0.00346      7.29196 *
+ * Al             93     -0.00091      0.00005      0.02179 *
+ * Al             94      0.00008     -0.00013      0.24724 *
+ * Al             95      0.01899     -0.00099      0.85873 *
+ * Al             96     -0.00452      0.00656      1.97496 *
+ * Al             97     -0.00051     -0.00040     -0.01600 *
+ * Al             98     -0.00916      0.01113     -0.85929 *
+ * Al             99     -0.00730     -0.00784     -1.96441 *
+ * Al            100     -0.00028      0.00031     -0.22602 *
+ * Al            101     -0.00107     -0.00016     -0.08311 *
+ * Al            102     -0.00066      0.00021      0.08539 *
+ * Al            103     -0.00079     -0.02233     -7.28968 *
+ * Al            104     -0.00534      0.01107      7.29412 *
+ * Al            105     -0.00026     -0.00007      0.02154 *
+ * Al            106     -0.00040     -0.00008      0.24692 *
+ * Al            107      0.00822      0.00515      0.86436 *
+ * Al            108     -0.01029      0.00234      1.97353 *
+ *                                                          *
+ ************************************************************
+
+Writing analysis data to al3x3.castep_bin
+
+Writing model to al3x3.check
+ 
+ A BibTeX formatted list of references used in this run has been written to 
+ al3x3.bib
+ 
+Initialisation time =      2.18 s
+Calculation time    =    122.20 s
+Finalisation time   =      1.79 s
+Total time          =    126.16 s
+Peak Memory Use     = 1722620 kB
+  
+Overall parallel efficiency rating: Terrible (32%)                              
+  
+Data was distributed by:-
+G-vector (512-way); efficiency rating: Terrible (34%)                           
+k-point (2-way); efficiency rating: Excellent (91%)                             
+  
+Parallel notes:
+1) Calculation only took 124.4 s, so efficiency estimates may be inaccurate.    


### PR DESCRIPTION
We're looking at this as we've got mostly-CASTEP  projects on the nationally-allocated portion of Sulis during the first allocation period.

Single node performance is a little ahead of ARCHER2 which @aturner-epcc  suggests is likely due to turboboost.
Multinode performance is worse than ARCHER2 as might be expected.

I haven't attempted to muck around with the Jupyter notebook to plots these yet.